### PR TITLE
[iOS] 공통 버튼 컴포넌트 (OhMyCarSetButton) 구현

### DIFF
--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		471917C22A7E422900B67D54 /* OhMyCarSetButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */; };
 		477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620C42A7B80B900D60B59 /* UILabel+.swift */; };
 		477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */; };
 		47CB8CB12A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */; };
@@ -83,6 +84,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButtonViewController.swift; sourceTree = "<group>"; };
 		477620C42A7B80B900D60B59 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButton.swift; sourceTree = "<group>"; };
 		47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRMedium.ttf; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				478B26832A78FD4000598902 /* SelfMode */,
 				5F00FBF82A777BDE0055A4FA /* ViewController.swift */,
 				477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */,
+				471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -677,6 +680,7 @@
 				47CB8CB92A79F1DE004B24AD /* Fonts.swift in Sources */,
 				5F00FBF92A777BDE0055A4FA /* ViewController.swift in Sources */,
 				477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */,
+				471917C22A7E422900B67D54 /* OhMyCarSetButtonViewController.swift in Sources */,
 				477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */,
 				5F3B50B92A79EDA900158E96 /* Colors.swift in Sources */,
 				5F62039B2A7BC86900D09531 /* OhMyCarSetNavigationBar.swift in Sources */,

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620C42A7B80B900D60B59 /* UILabel+.swift */; };
+		477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */; };
 		47CB8CB12A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */; };
 		47CB8CB32A79ECE0004B24AD /* HyundaiSansHeadKRRegular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 47CB8CB22A79ECE0004B24AD /* HyundaiSansHeadKRRegular.ttf */; };
 		47CB8CB52A79EDB3004B24AD /* HyundaiSansTextKROTFMedium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 47CB8CB42A79EDB3004B24AD /* HyundaiSansTextKROTFMedium.otf */; };
@@ -83,6 +84,7 @@
 
 /* Begin PBXFileReference section */
 		477620C42A7B80B900D60B59 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButton.swift; sourceTree = "<group>"; };
 		47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRMedium.ttf; sourceTree = "<group>"; };
 		47CB8CB22A79ECE0004B24AD /* HyundaiSansHeadKRRegular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRRegular.ttf; sourceTree = "<group>"; };
 		47CB8CB42A79EDB3004B24AD /* HyundaiSansTextKROTFMedium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansTextKROTFMedium.otf; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 			children = (
 				478B26832A78FD4000598902 /* SelfMode */,
 				5F00FBF82A777BDE0055A4FA /* ViewController.swift */,
+				477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -674,6 +677,7 @@
 				47CB8CB92A79F1DE004B24AD /* Fonts.swift in Sources */,
 				5F00FBF92A777BDE0055A4FA /* ViewController.swift in Sources */,
 				477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */,
+				477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */,
 				5F3B50B92A79EDA900158E96 /* Colors.swift in Sources */,
 				5F62039B2A7BC86900D09531 /* OhMyCarSetNavigationBar.swift in Sources */,
 				5F00FBF52A777BDE0055A4FA /* AppDelegate.swift in Sources */,

--- a/iOS_H3/iOS_H3/Resource/Colors.swift
+++ b/iOS_H3/iOS_H3/Resource/Colors.swift
@@ -7,13 +7,13 @@
 
 import UIKit
 enum Colors {
-    static let mainHyundaiBlue = UIColor.init(hex: "#0E2B5C")
-    static let subActiveBlue = UIColor.init(hex: "#4CA7CE")
-    static let iconYellow = UIColor.init(hex: "#FFA724")
-    static let tagSkyBlue = UIColor.init(hex: "#DEEBFF")
-    static let coolGreyBlack = UIColor.init(hex: "#202732")
-    static let coolGrey4 = UIColor.init(hex: "#595C61")
-    static let coolGrey3 = UIColor.init(hex: "#A5ACB8")
-    static let coolGrey2 = UIColor.init(hex: "#D1D9E3")
-    static let coolGrey1 = UIColor.init(hex: "#EDF2FA")
+    static let mainHyundaiBlue = UIColor.init(hex: "#0E2B5C") ?? .red
+    static let subActiveBlue = UIColor.init(hex: "#4CA7CE") ?? .red
+    static let iconYellow = UIColor.init(hex: "#FFA724") ?? .red
+    static let tagSkyBlue = UIColor.init(hex: "#DEEBFF") ?? .red
+    static let coolGreyBlack = UIColor.init(hex: "#202732") ?? .red
+    static let coolGrey4 = UIColor.init(hex: "#595C61") ?? .red
+    static let coolGrey3 = UIColor.init(hex: "#A5ACB8") ?? .red
+    static let coolGrey2 = UIColor.init(hex: "#D1D9E3") ?? .red
+    static let coolGrey1 = UIColor.init(hex: "#EDF2FA") ?? .red
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
@@ -51,6 +51,16 @@ final class OhMyCarSetButton: UIButton {
 
     var colorType: ColorType
 
+    override var isEnabled: Bool {
+        didSet {
+            if isEnabled {
+                setupViewsForColorType()
+            } else {
+                setupDisabledView()
+            }
+        }
+    }
+
     // MARK: - Lifecycles
 
     init(colorType: ColorType, title: String) {

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
@@ -45,6 +45,7 @@ final class OhMyCarSetButton: UIButton {
 
     enum Constants {
         static let cornerRadius = 6.0
+        static let borderWidth = 1.0
     }
 
     // MARK: - Properties
@@ -123,7 +124,7 @@ extension OhMyCarSetButton {
         backgroundColor = colorType.backgroundColor
         setTitleColor(colorType.titleColor, for: .normal)
         if colorType.hasBorder {
-            addBorder(width: 1, color: .black)
+            addBorder(width: Constants.borderWidth, color: .black)
         }
     }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
@@ -47,25 +47,32 @@ final class OhMyCarSetButton: UIButton {
         static let cornerRadius = 6.0
     }
 
+    // MARK: - Properties
+
+    var colorType: ColorType
+
     // MARK: - Lifecycles
 
     init(colorType: ColorType, title: String) {
+        self.colorType = colorType
         super.init(frame: .zero)
 
-        setupViews(for: colorType)
+        setupViews()
         setTitle(title, for: .normal)
     }
 
     override init(frame: CGRect) {
+        self.colorType = .mainHyundaiBlue
         super.init(frame: frame)
 
-        setupViews(for: .mainHyundaiBlue)
+        setupViews()
     }
 
     required init?(coder: NSCoder) {
+        self.colorType = .mainHyundaiBlue
         super.init(coder: coder)
 
-        setupViews(for: .mainHyundaiBlue)
+        setupViews()
     }
 
     // MARK: - Helpers
@@ -86,10 +93,10 @@ final class OhMyCarSetButton: UIButton {
 }
 
 extension OhMyCarSetButton {
-    private func setupViews(for colorType: ColorType) {
+    private func setupViews() {
         setupRadius()
         setupLabelFont()
-        setupViewsForType(colorType)
+        setupViewsForColorType()
     }
 
     private func setupRadius() {
@@ -102,7 +109,7 @@ extension OhMyCarSetButton {
         titleLabel?.setupLetterSpacing(FontLetterSpacings.mediumBody2)
     }
 
-    private func setupViewsForType(_ colorType: ColorType) {
+    private func setupViewsForColorType() {
         backgroundColor = colorType.backgroundColor
         setTitleColor(colorType.titleColor, for: .normal)
         if colorType.hasBorder {

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
@@ -1,0 +1,112 @@
+//
+//  OhMyCarSetButton.swift
+//  iOS_H3_UI
+//
+//  Created by  sangyeon on 2023/08/03.
+//
+
+import UIKit
+
+final class OhMyCarSetButton: UIButton {
+
+    enum ColorType {
+        case mainHyundaiBlue
+        case white
+        case coolGrey1
+        case grey   // color 새로 정의 필요할듯 (프론트까지 같이 얘기해서?)
+
+        var backgroundColor: UIColor {
+            switch self {
+            case .mainHyundaiBlue: return Colors.mainHyundaiBlue
+            case .white: return .white
+            case .coolGrey1: return Colors.coolGrey1
+            case .grey: return UIColor(hex: "#E8E8E8") ?? .red
+            }
+        }
+
+        var titleColor: UIColor {
+            switch self {
+            case .mainHyundaiBlue: return .white
+            case .white: return .black
+            case .coolGrey1: return Colors.mainHyundaiBlue
+            case .grey: return Colors.mainHyundaiBlue
+            }
+        }
+
+        var hasBorder: Bool {
+            switch self {
+            case .white: return true
+            default: return false
+            }
+        }
+    }
+
+    // MARK: - UI properties
+
+    enum Constants {
+        static let cornerRadius = 6.0
+    }
+
+    // MARK: - Lifecycles
+
+    init(colorType: ColorType, title: String) {
+        super.init(frame: .zero)
+        
+        setupViews(for: colorType)
+        setTitle(title, for: .normal)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupViews(for: .mainHyundaiBlue)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setupViews(for: .mainHyundaiBlue)
+    }
+
+    // MARK: - Helpers
+
+    func changeColor(titleColor: UIColor, backgroundColor: UIColor) {
+        self.backgroundColor = backgroundColor
+        self.setTitleColor(titleColor, for: .normal)
+    }
+
+    func addBorder(width: CGFloat, color: UIColor) {
+        self.layer.borderWidth = width
+        self.layer.borderColor = color.cgColor
+    }
+
+    func setupDisabledView() {
+        changeColor(titleColor: Colors.coolGrey3, backgroundColor: Colors.coolGrey1)
+    }
+}
+
+extension OhMyCarSetButton {
+    private func setupViews(for colorType: ColorType) {
+        setupRadius()
+        setupLabelFont()
+        setupViewsForType(colorType)
+    }
+
+    private func setupRadius() {
+        self.layer.cornerRadius = Constants.cornerRadius
+    }
+
+    private func setupLabelFont() {
+        titleLabel?.font = Fonts.mediumBody2
+        titleLabel?.setupLineHeight(FontLineHeights.mediumBody2)
+        titleLabel?.setupLetterSpacing(FontLetterSpacings.mediumBody2)
+    }
+
+    private func setupViewsForType(_ colorType: ColorType) {
+        backgroundColor = colorType.backgroundColor
+        setTitleColor(colorType.titleColor, for: .normal)
+        if colorType.hasBorder {
+            addBorder(width: 1, color: .black)
+        }
+    }
+}

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButton.swift
@@ -51,20 +51,20 @@ final class OhMyCarSetButton: UIButton {
 
     init(colorType: ColorType, title: String) {
         super.init(frame: .zero)
-        
+
         setupViews(for: colorType)
         setTitle(title, for: .normal)
     }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         setupViews(for: .mainHyundaiBlue)
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        
+
         setupViews(for: .mainHyundaiBlue)
     }
 

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
@@ -8,18 +8,56 @@
 import UIKit
 
 final class OhMyCarSetButtonViewController: UIViewController {
+    
+    let mainBlueButton: OhMyCarSetButton = {
+        let button = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    let whiteButton: OhMyCarSetButton = {
+        let button = OhMyCarSetButton(colorType: .white, title: "시승 신청하기")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    let coolGreyButton: OhMyCarSetButton = {
+        let button = OhMyCarSetButton(colorType: .coolGrey1, title: "변경할래요!")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    let greyButton: OhMyCarSetButton = {
+        let button = OhMyCarSetButton(colorType: .grey, title: "공유하기")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    let disabledButton: OhMyCarSetButton = {
+        let button = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
+        button.isEnabled = false
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = .white
-        setupButtons()
+        addSubviews()
+        setupConstraints()
     }
-
-    private func setupButtons() {
-        let mainBlueButton = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
-        mainBlueButton.translatesAutoresizingMaskIntoConstraints = false
+    
+    private func addSubviews() {
         view.addSubview(mainBlueButton)
+        view.addSubview(whiteButton)
+        view.addSubview(coolGreyButton)
+        view.addSubview(greyButton)
+        view.addSubview(disabledButton)
+    }
+    
+    private func setupConstraints() {
         NSLayoutConstraint.activate([
             mainBlueButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             mainBlueButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
@@ -27,9 +65,6 @@ final class OhMyCarSetButtonViewController: UIViewController {
             mainBlueButton.heightAnchor.constraint(equalToConstant: 50)
         ])
 
-        let whiteButton = OhMyCarSetButton(colorType: .white, title: "시승 신청하기")
-        whiteButton.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(whiteButton)
         NSLayoutConstraint.activate([
             whiteButton.topAnchor.constraint(equalTo: mainBlueButton.bottomAnchor, constant: 10),
             whiteButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
@@ -37,9 +72,6 @@ final class OhMyCarSetButtonViewController: UIViewController {
             whiteButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
         ])
 
-        let coolGreyButton = OhMyCarSetButton(colorType: .coolGrey1, title: "변경할래요!")
-        coolGreyButton.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(coolGreyButton)
         NSLayoutConstraint.activate([
             coolGreyButton.topAnchor.constraint(equalTo: whiteButton.bottomAnchor, constant: 10),
             coolGreyButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
@@ -47,9 +79,6 @@ final class OhMyCarSetButtonViewController: UIViewController {
             coolGreyButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
         ])
 
-        let greyButton = OhMyCarSetButton(colorType: .grey, title: "공유하기")
-        greyButton.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(greyButton)
         NSLayoutConstraint.activate([
             greyButton.topAnchor.constraint(equalTo: coolGreyButton.bottomAnchor, constant: 10),
             greyButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
@@ -57,15 +86,11 @@ final class OhMyCarSetButtonViewController: UIViewController {
             greyButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
         ])
 
-        let disabledButton = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
-        disabledButton.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(disabledButton)
         NSLayoutConstraint.activate([
             disabledButton.topAnchor.constraint(equalTo: greyButton.bottomAnchor, constant: 10),
             disabledButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
             disabledButton.trailingAnchor.constraint(equalTo: mainBlueButton.trailingAnchor),
             disabledButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
         ])
-        disabledButton.isEnabled = false
     }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class OhMyCarSetButtonViewController: UIViewController {
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
@@ -8,38 +8,37 @@
 import UIKit
 
 final class OhMyCarSetButtonViewController: UIViewController {
-    
+
     let mainBlueButton: OhMyCarSetButton = {
         let button = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-    
+
     let whiteButton: OhMyCarSetButton = {
         let button = OhMyCarSetButton(colorType: .white, title: "시승 신청하기")
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-    
+
     let coolGreyButton: OhMyCarSetButton = {
         let button = OhMyCarSetButton(colorType: .coolGrey1, title: "변경할래요!")
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-    
+
     let greyButton: OhMyCarSetButton = {
         let button = OhMyCarSetButton(colorType: .grey, title: "공유하기")
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-    
+
     let disabledButton: OhMyCarSetButton = {
         let button = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
         button.isEnabled = false
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -48,7 +47,7 @@ final class OhMyCarSetButtonViewController: UIViewController {
         addSubviews()
         setupConstraints()
     }
-    
+
     private func addSubviews() {
         view.addSubview(mainBlueButton)
         view.addSubview(whiteButton)
@@ -56,7 +55,7 @@ final class OhMyCarSetButtonViewController: UIViewController {
         view.addSubview(greyButton)
         view.addSubview(disabledButton)
     }
-    
+
     private func setupConstraints() {
         NSLayoutConstraint.activate([
             mainBlueButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),

--- a/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OhMyCarSetButtonViewController.swift
@@ -1,0 +1,71 @@
+//
+//  OhMyCarSetButtonViewController.swift
+//  iOS_H3
+//
+//  Created by  sangyeon on 2023/08/05.
+//
+
+import UIKit
+
+final class OhMyCarSetButtonViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+        setupButtons()
+    }
+
+    private func setupButtons() {
+        let mainBlueButton = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
+        mainBlueButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(mainBlueButton)
+        NSLayoutConstraint.activate([
+            mainBlueButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            mainBlueButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            mainBlueButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            mainBlueButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
+
+        let whiteButton = OhMyCarSetButton(colorType: .white, title: "시승 신청하기")
+        whiteButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(whiteButton)
+        NSLayoutConstraint.activate([
+            whiteButton.topAnchor.constraint(equalTo: mainBlueButton.bottomAnchor, constant: 10),
+            whiteButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
+            whiteButton.trailingAnchor.constraint(equalTo: mainBlueButton.trailingAnchor),
+            whiteButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
+        ])
+
+        let coolGreyButton = OhMyCarSetButton(colorType: .coolGrey1, title: "변경할래요!")
+        coolGreyButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(coolGreyButton)
+        NSLayoutConstraint.activate([
+            coolGreyButton.topAnchor.constraint(equalTo: whiteButton.bottomAnchor, constant: 10),
+            coolGreyButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
+            coolGreyButton.trailingAnchor.constraint(equalTo: mainBlueButton.trailingAnchor),
+            coolGreyButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
+        ])
+
+        let greyButton = OhMyCarSetButton(colorType: .grey, title: "공유하기")
+        greyButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(greyButton)
+        NSLayoutConstraint.activate([
+            greyButton.topAnchor.constraint(equalTo: coolGreyButton.bottomAnchor, constant: 10),
+            greyButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
+            greyButton.trailingAnchor.constraint(equalTo: mainBlueButton.trailingAnchor),
+            greyButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
+        ])
+
+        let disabledButton = OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택완료")
+        disabledButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(disabledButton)
+        NSLayoutConstraint.activate([
+            disabledButton.topAnchor.constraint(equalTo: greyButton.bottomAnchor, constant: 10),
+            disabledButton.leadingAnchor.constraint(equalTo: mainBlueButton.leadingAnchor),
+            disabledButton.trailingAnchor.constraint(equalTo: mainBlueButton.trailingAnchor),
+            disabledButton.heightAnchor.constraint(equalTo: mainBlueButton.heightAnchor)
+        ])
+        disabledButton.isEnabled = false
+    }
+}


### PR DESCRIPTION
## 🔖 관련 이슈
- #22 

## 📝 구현 사항

### OhMyCarSet 버튼 구현

- 둥근 테두리와 label의 폰트, 배경 색상이 설정된 공통 버튼 컴포넌트를 구현
- **배경 색상**에 따라 4가지 버튼 타입 (`OhMyCarSetButton.ColorType`)을 구분
  - mainHyundaiBlue, white, coolGrey1, grey
- 버튼 `isEnabled = false`가 되었을 경우, 내부적으로 `setupDisabledView()`을 호출하여 뷰를 업데이트

  `isEnabled = false`인 경우 |
  --- |
  <img width="309" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/aababdde-c144-4e7d-ba95-bc03baca0906">|

- 사용 방법
  - 버튼 생성 시 colorType과 title을 전달
  `OhMyCarSetButton(colorType: .mainHyundaiBlue, title: "선택 완료")`
  - 4가지 버튼 타입 외 다른 버튼을 생성하고 싶은 경우
    ```swift
    func changeColor(titleColor: UIColor, backgroundColor: UIColor)
    func addBorder(width: CGFloat, color: UIColor)
    ```
      두 가지 함수를 이용하여 커스텀 할 수 있습니다.

4가지 버튼 타입 예시 |
---|
<img width="349" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/9ebef311-3864-4d17-a61a-bffc8d30e1da"> |

### OhMyCarSetButtonViewController 구현

- OhMyCarSetButton 사용 예시를 위한 ViewController를 구현

## 📌 하고싶은 말

### 색상 관련 참고 사항
- grey는 figma의 제너럴 컴포넌트 속 색상에 포함되지 않은 컬러였어서 임의로 이름을 지정했는데, 색상 이름 관련하여 회의가 필요할 것 같습니다
- 또한 coolGrey1도 제너럴 컴포넌트 속 coolGrey1 색상과 실제 디자인에서 사용된 coolGrey1 색상이 달라서, 마찬가지로 회의가 필요할 것 같습니다.

grey 색상 | 제너럴 컴포넌트의 coolGrey1 | 디자인의 coolGrey1
---|---|---
<img width="449" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/26d3c2ef-3f6e-4813-b988-2f10392dde0b"> | <img width="491" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/51680e33-83f3-4db9-acda-3208b35b8f38"> | <img width="492" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/9d81177f-0be9-44fd-b5bc-bfaa60f274be">

closes #22 