### PR TITLE
[iOS] TwoOptionCardButtonView 구현

### DIFF
--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		471917C22A7E422900B67D54 /* OhMyCarSetButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */; };
 		471917D02A80E69A00B67D54 /* TwoOptionCardButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */; };
+		471917D22A8118E200B67D54 /* TwoOptionCardButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */; };
 		471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D52A811D3F00B67D54 /* OptionCardInfo.swift */; };
 		477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620C42A7B80B900D60B59 /* UILabel+.swift */; };
 		477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */; };
@@ -94,6 +95,7 @@
 /* Begin PBXFileReference section */
 		471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButtonViewController.swift; sourceTree = "<group>"; };
 		471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoOptionCardButtonView.swift; sourceTree = "<group>"; };
+		471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoOptionCardButtonViewController.swift; sourceTree = "<group>"; };
 		471917D52A811D3F00B67D54 /* OptionCardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardInfo.swift; sourceTree = "<group>"; };
 		477620C42A7B80B900D60B59 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButton.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */,
 				471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */,
 				471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */,
+				471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -730,6 +733,7 @@
 				5F2593E22A7FCA16001B2D84 /* OptionCardButtonViewController.swift in Sources */,
 				5F2593E02A7FBCFE001B2D84 /* OptionMotionView.swift in Sources */,
 				471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */,
+				471917D22A8118E200B67D54 /* TwoOptionCardButtonViewController.swift in Sources */,
 				5F3B50BB2A79EDE900158E96 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		471917D22A8118E200B67D54 /* TwoOptionCardButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */; };
 		471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D52A811D3F00B67D54 /* OptionCardInfo.swift */; };
 		471917DE2A81F9A200B67D54 /* OptionCardButtonListViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917DD2A81F9A200B67D54 /* OptionCardButtonListViewable.swift */; };
+		471917E42A8221D800B67D54 /* TwoMoreInfoOptionCardButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917E32A8221D800B67D54 /* TwoMoreInfoOptionCardButtonView.swift */; };
 		477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620C42A7B80B900D60B59 /* UILabel+.swift */; };
 		477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */; };
 		47CB8CB12A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */; };
@@ -99,6 +100,7 @@
 		471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoOptionCardButtonViewController.swift; sourceTree = "<group>"; };
 		471917D52A811D3F00B67D54 /* OptionCardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardInfo.swift; sourceTree = "<group>"; };
 		471917DD2A81F9A200B67D54 /* OptionCardButtonListViewable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OptionCardButtonListViewable.swift; path = iOS_H3/Source/Presentation/OptionCardButtonListViewable.swift; sourceTree = SOURCE_ROOT; };
+		471917E32A8221D800B67D54 /* TwoMoreInfoOptionCardButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoMoreInfoOptionCardButtonView.swift; sourceTree = "<group>"; };
 		477620C42A7B80B900D60B59 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButton.swift; sourceTree = "<group>"; };
 		47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRMedium.ttf; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */,
 				471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */,
 				471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */,
+				471917E32A8221D800B67D54 /* TwoMoreInfoOptionCardButtonView.swift */,
 				471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */,
 				471917DD2A81F9A200B67D54 /* OptionCardButtonListViewable.swift */,
 			);
@@ -734,6 +737,7 @@
 				5F00FBF72A777BDE0055A4FA /* SceneDelegate.swift in Sources */,
 				471917D02A80E69A00B67D54 /* TwoOptionCardButtonView.swift in Sources */,
 				5F2593E22A7FCA16001B2D84 /* OptionCardButtonViewController.swift in Sources */,
+				471917E42A8221D800B67D54 /* TwoMoreInfoOptionCardButtonView.swift in Sources */,
 				5F2593E02A7FBCFE001B2D84 /* OptionMotionView.swift in Sources */,
 				471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */,
 				471917D22A8118E200B67D54 /* TwoOptionCardButtonViewController.swift in Sources */,

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -936,6 +936,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOS_H3/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -947,7 +948,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.umocha-racer.iOS-H3";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.softeer.H3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -965,6 +966,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOS_H3/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -976,7 +978,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.umocha-racer.iOS-H3";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.softeer.H3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		471917D02A80E69A00B67D54 /* TwoOptionCardButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */; };
 		471917D22A8118E200B67D54 /* TwoOptionCardButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */; };
 		471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D52A811D3F00B67D54 /* OptionCardInfo.swift */; };
+		471917DE2A81F9A200B67D54 /* OptionCardButtonListViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917DD2A81F9A200B67D54 /* OptionCardButtonListViewable.swift */; };
 		477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620C42A7B80B900D60B59 /* UILabel+.swift */; };
 		477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */; };
 		47CB8CB12A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */; };
@@ -97,6 +98,7 @@
 		471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoOptionCardButtonView.swift; sourceTree = "<group>"; };
 		471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoOptionCardButtonViewController.swift; sourceTree = "<group>"; };
 		471917D52A811D3F00B67D54 /* OptionCardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardInfo.swift; sourceTree = "<group>"; };
+		471917DD2A81F9A200B67D54 /* OptionCardButtonListViewable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OptionCardButtonListViewable.swift; path = iOS_H3/Source/Presentation/OptionCardButtonListViewable.swift; sourceTree = SOURCE_ROOT; };
 		477620C42A7B80B900D60B59 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButton.swift; sourceTree = "<group>"; };
 		47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRMedium.ttf; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 				471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */,
 				471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */,
 				471917D12A8118E200B67D54 /* TwoOptionCardButtonViewController.swift */,
+				471917DD2A81F9A200B67D54 /* OptionCardButtonListViewable.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -714,6 +717,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F5F724D2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift in Sources */,
+				471917DE2A81F9A200B67D54 /* OptionCardButtonListViewable.swift in Sources */,
 				47CB8CB92A79F1DE004B24AD /* Fonts.swift in Sources */,
 				5F00FBF92A777BDE0055A4FA /* ViewController.swift in Sources */,
 				5F3D88192A7C72C7004C5AD2 /* OhMyCarSetTitleBar.swift in Sources */,

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		471917C22A7E422900B67D54 /* OhMyCarSetButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */; };
+		471917D02A80E69A00B67D54 /* TwoOptionCardButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */; };
 		471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D52A811D3F00B67D54 /* OptionCardInfo.swift */; };
 		477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620C42A7B80B900D60B59 /* UILabel+.swift */; };
 		477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */; };
@@ -92,6 +93,7 @@
 
 /* Begin PBXFileReference section */
 		471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButtonViewController.swift; sourceTree = "<group>"; };
+		471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoOptionCardButtonView.swift; sourceTree = "<group>"; };
 		471917D52A811D3F00B67D54 /* OptionCardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardInfo.swift; sourceTree = "<group>"; };
 		477620C42A7B80B900D60B59 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButton.swift; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 				5F5F724B2A7E00FC0084AFD4 /* TitleBar */,
 				477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */,
 				471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */,
+				471917CF2A80E69A00B67D54 /* TwoOptionCardButtonView.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -723,6 +726,7 @@
 				5F00FBF52A777BDE0055A4FA /* AppDelegate.swift in Sources */,
 				5F2593D82A7FB385001B2D84 /* MoreInfoOptionButton.swift in Sources */,
 				5F00FBF72A777BDE0055A4FA /* SceneDelegate.swift in Sources */,
+				471917D02A80E69A00B67D54 /* TwoOptionCardButtonView.swift in Sources */,
 				5F2593E22A7FCA16001B2D84 /* OptionCardButtonViewController.swift in Sources */,
 				5F2593E02A7FBCFE001B2D84 /* OptionMotionView.swift in Sources */,
 				471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */,

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		471917C22A7E422900B67D54 /* OhMyCarSetButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */; };
+		471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471917D52A811D3F00B67D54 /* OptionCardInfo.swift */; };
 		477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620C42A7B80B900D60B59 /* UILabel+.swift */; };
 		477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */; };
 		47CB8CB12A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */; };
@@ -91,6 +92,7 @@
 
 /* Begin PBXFileReference section */
 		471917C12A7E422900B67D54 /* OhMyCarSetButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButtonViewController.swift; sourceTree = "<group>"; };
+		471917D52A811D3F00B67D54 /* OptionCardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardInfo.swift; sourceTree = "<group>"; };
 		477620C42A7B80B900D60B59 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		477620F42A7BECC400D60B59 /* OhMyCarSetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetButton.swift; sourceTree = "<group>"; };
 		47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRMedium.ttf; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 		478B26822A78FD3800598902 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				471917D52A811D3F00B67D54 /* OptionCardInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -722,6 +725,7 @@
 				5F00FBF72A777BDE0055A4FA /* SceneDelegate.swift in Sources */,
 				5F2593E22A7FCA16001B2D84 /* OptionCardButtonViewController.swift in Sources */,
 				5F2593E02A7FBCFE001B2D84 /* OptionMotionView.swift in Sources */,
+				471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */,
 				5F3B50BB2A79EDE900158E96 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -126,8 +126,8 @@
 		5F3B50BA2A79EDE900158E96 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		5F3D88182A7C72C7004C5AD2 /* OhMyCarSetTitleBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OhMyCarSetTitleBar.swift; path = iOS_H3/Source/Presentation/TitleBar/OhMyCarSetTitleBar.swift; sourceTree = SOURCE_ROOT; };
 		5F5E21122A78DD21003C1185 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
-		5F5F72502A7E13600084AFD4 /* OptionCardButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardButton.swift; sourceTree = "<group>"; };
 		5F5F724C2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetTitleBarViewController.swift; sourceTree = "<group>"; };
+		5F5F72502A7E13600084AFD4 /* OptionCardButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardButton.swift; sourceTree = "<group>"; };
 		5F6203662A7BC59500D09531 /* iOS_H3_UI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOS_H3_UI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F6203682A7BC59500D09531 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5F62036A2A7BC59500D09531 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -412,6 +412,15 @@
 			path = iOS_H3UITests;
 			sourceTree = "<group>";
 		};
+		5F5F724B2A7E00FC0084AFD4 /* TitleBar */ = {
+			isa = PBXGroup;
+			children = (
+				5F3D88182A7C72C7004C5AD2 /* OhMyCarSetTitleBar.swift */,
+				5F5F724C2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift */,
+			);
+			path = TitleBar;
+			sourceTree = "<group>";
+		};
 		5F5F724F2A7E12970084AFD4 /* OptionCardButton */ = {
 			isa = PBXGroup;
 			children = (
@@ -424,15 +433,6 @@
 				5F2593E12A7FCA16001B2D84 /* OptionCardButtonViewController.swift */,
 			);
 			path = OptionCardButton;
-			sourceTree = "<group>";
-		};
-		5F5F724B2A7E00FC0084AFD4 /* TitleBar */ = {
-			isa = PBXGroup;
-			children = (
-				5F3D88182A7C72C7004C5AD2 /* OhMyCarSetTitleBar.swift */,
-				5F5F724C2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift */,
-			);
-			path = TitleBar;
 			sourceTree = "<group>";
 		};
 		5F6203672A7BC59500D09531 /* iOS_H3_UI */ = {
@@ -725,7 +725,6 @@
 				477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */,
 				5F3B50B92A79EDA900158E96 /* Colors.swift in Sources */,
 				5F2593DC2A7FB3CE001B2D84 /* ColorViewOptionCardButton.swift in Sources */,
-				5F62039B2A7BC86900D09531 /* OhMyCarSetNavigationBar.swift in Sources */,
 				5F00FBF52A777BDE0055A4FA /* AppDelegate.swift in Sources */,
 				5F2593D82A7FB385001B2D84 /* MoreInfoOptionButton.swift in Sources */,
 				5F00FBF72A777BDE0055A4FA /* SceneDelegate.swift in Sources */,

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -954,6 +954,7 @@
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOS_H3/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = H3UmochaRacer;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -984,6 +985,7 @@
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOS_H3/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = H3UmochaRacer;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;

--- a/iOS_H3/iOS_H3/Source/Domain/Model/OptionCardInfo.swift
+++ b/iOS_H3/iOS_H3/Source/Domain/Model/OptionCardInfo.swift
@@ -10,5 +10,5 @@ import Foundation
 struct OptionCardInfo {
     let title: String
     let subTitle: String
-    let priceString: String
+    let priceString: String     // 예시) "+ 100,000원"
 }

--- a/iOS_H3/iOS_H3/Source/Domain/Model/OptionCardInfo.swift
+++ b/iOS_H3/iOS_H3/Source/Domain/Model/OptionCardInfo.swift
@@ -1,0 +1,14 @@
+//
+//  OptionCardInfo.swift
+//  iOS_H3
+//
+//  Created by  sangyeon on 2023/08/07.
+//
+
+import Foundation
+
+struct OptionCardInfo {
+    let title: String
+    let subTitle: String
+    let priceString: String
+}

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/ColorViewOptionCardButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/ColorViewOptionCardButton.swift
@@ -20,7 +20,7 @@ class ColorViewOptionCardButton: OptionCardButton {
                   optionTitle: String = "옵션 타이틀",
                   optionSubTitle: String = "옵션 서브 타이틀",
                   price: String = "+ 0원") {
-        super.init(type: type)
+        super.init(type: type, optionTitle: optionTitle, optionSubTitle: optionSubTitle, price: price)
         layout()
         attribute()
     }

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/ImageDisplayOptionButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/ImageDisplayOptionButton.swift
@@ -20,7 +20,7 @@ class ImageDisplayOptionButton: OptionCardButton {
                   optionTitle: String = "옵션 타이틀",
                   optionSubTitle: String = "옵션 서브 타이틀",
                   price: String = "+ 0원") {
-        super.init(type: type)
+        super.init(type: type, optionTitle: optionTitle, optionSubTitle: optionSubTitle, price: price)
         layout()
     }
 

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/MoreInfoOptionButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/MoreInfoOptionButton.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 import UIKit
+
+protocol MoreInfoOptionButtonDelegate: AnyObject {
+    func moreInfoButtonPressed()
+}
+
 // 자세히보기 옵션 버튼
 class MoreInfoOptionButton: OptionCardButton {
 
@@ -16,12 +21,15 @@ class MoreInfoOptionButton: OptionCardButton {
         return button
     }()
 
+    weak var delegate: MoreInfoOptionButtonDelegate?
+
     override init(type: OptionCardButton.OptionCardType,
                   optionTitle: String = "옵션 타이틀",
                   optionSubTitle: String = "옵션 서브 타이틀",
                   price: String = "+ 0원") {
         super.init(type: type, optionTitle: optionTitle, optionSubTitle: optionSubTitle, price: price)
         layout()
+        addMoreInfoButtonTarget()
     }
 
     required init?(coder: NSCoder) {
@@ -38,4 +46,12 @@ class MoreInfoOptionButton: OptionCardButton {
         moreInfoButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10).isActive = true
     }
 
+    private func addMoreInfoButtonTarget() {
+        moreInfoButton.addTarget(self, action: #selector(moreInfoButtonTapped), for: .touchUpInside)
+    }
+
+    @objc
+    private func moreInfoButtonTapped() {
+        delegate?.moreInfoButtonPressed()
+    }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/MoreInfoOptionButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/MoreInfoOptionButton.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 protocol MoreInfoOptionButtonDelegate: AnyObject {
-    func moreInfoButtonPressed()
+    func moreInfoButtonDidTapped()
 }
 
 // 자세히보기 옵션 버튼
@@ -52,6 +52,6 @@ class MoreInfoOptionButton: OptionCardButton {
 
     @objc
     private func moreInfoButtonTapped() {
-        delegate?.moreInfoButtonPressed()
+        delegate?.moreInfoButtonDidTapped()
     }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/MoreInfoOptionButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/MoreInfoOptionButton.swift
@@ -9,9 +9,9 @@ import Foundation
 import UIKit
 // 자세히보기 옵션 버튼
 class MoreInfoOptionButton: OptionCardButton {
+
     private let moreInfoButton: UIButton = {
         let button = UIButton()
-
         button.setImage(UIImage(named: "arrow_right_img") ?? .remove, for: .normal)
         return button
     }()
@@ -20,7 +20,7 @@ class MoreInfoOptionButton: OptionCardButton {
                   optionTitle: String = "옵션 타이틀",
                   optionSubTitle: String = "옵션 서브 타이틀",
                   price: String = "+ 0원") {
-        super.init(type: type)
+        super.init(type: type, optionTitle: optionTitle, optionSubTitle: optionSubTitle, price: price)
         layout()
     }
 
@@ -36,7 +36,6 @@ class MoreInfoOptionButton: OptionCardButton {
         moreInfoButton.heightAnchor.constraint(equalToConstant: 18).isActive = true
         moreInfoButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -18).isActive = true
         moreInfoButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10).isActive = true
-
     }
 
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/OptionCardButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/OptionCardButton.swift
@@ -43,6 +43,8 @@ class OptionCardButton: UIButton {
         let label = UILabel()
         label.isUserInteractionEnabled = false
         label.font = Fonts.regularBody3
+        label.setupLineHeight(FontLineHeights.regularBody3)
+        label.setupLetterSpacing(FontLetterSpacings.regularBody3)
         label.textColor = Colors.coolGrey3
         return label
     }()
@@ -50,6 +52,8 @@ class OptionCardButton: UIButton {
         let label = UILabel()
         label.isUserInteractionEnabled = false
         label.font = Fonts.mediumTitle2
+        label.setupLineHeight(FontLineHeights.mediumTitle2)
+        label.setupLetterSpacing(FontLetterSpacings.mediumTitle2)
         label.textColor = Colors.coolGrey3
         return label
     }()
@@ -57,6 +61,8 @@ class OptionCardButton: UIButton {
         let label = UILabel()
         label.isUserInteractionEnabled = false
         label.font = Fonts.regularBody2
+        label.setupLineHeight(FontLineHeights.regularBody2)
+        label.setupLetterSpacing(FontLetterSpacings.regularBody2)
         label.textColor = Colors.coolGrey3
         return label
     }()
@@ -150,7 +156,7 @@ class OptionCardButton: UIButton {
     }
 
     private func attribute() {
-        self.layer.cornerRadius = 10
+        self.layer.cornerRadius = 6
     }
 
     private func layout() {

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/OptionCardButton.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButton/OptionCardButton.swift
@@ -42,7 +42,7 @@ class OptionCardButton: UIButton {
     private let optionSubTitleLabel: UILabel = {
         let label = UILabel()
         label.isUserInteractionEnabled = false
-        label.font = Fonts.regularBody2
+        label.font = Fonts.regularBody3
         label.textColor = Colors.coolGrey3
         return label
     }()

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButtonListViewable.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButtonListViewable.swift
@@ -14,6 +14,8 @@ protocol OptionCardButtonListViewable: UIView {
 
 extension OptionCardButtonListViewable {
     func selectOption(index: Int) {
+        if !isValidateIndex(index) { return }
+
         optionCardButtons[selectedButtonIndex].isSelected = false
         optionCardButtons[index].isSelected = true
         selectedButtonIndex = index
@@ -21,6 +23,8 @@ extension OptionCardButtonListViewable {
 
     /// index에 해당하는 옵션 카드의 view를 업데이트
     func updateView(index: Int, with cardInfo: OptionCardInfo) {
+        if !isValidateIndex(index) { return }
+
         optionCardButtons[index].setOptionTitle(cardInfo.title)
         optionCardButtons[index].setOptionSubTitle(cardInfo.subTitle)
         optionCardButtons[index].setPrice(cardInfo.priceString)
@@ -31,5 +35,9 @@ extension OptionCardButtonListViewable {
         optionCardButtons.enumerated().forEach { (index, _) in
             updateView(index: index, with: cardInfos[index])
         }
+    }
+
+    private func isValidateIndex(_ index: Int) -> Bool {
+        0..<optionCardButtons.count ~= index
     }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionCardButtonListViewable.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionCardButtonListViewable.swift
@@ -1,0 +1,35 @@
+//
+//  OptionCardButtonListViewable.swift
+//  iOS_H3
+//
+//  Created by  sangyeon on 2023/08/08.
+//
+
+import UIKit
+
+protocol OptionCardButtonListViewable: UIView {
+    var optionCardButtons: [OptionCardButton] { get }
+    var selectedButtonIndex: Int { get set }
+}
+
+extension OptionCardButtonListViewable {
+    func selectOption(index: Int) {
+        optionCardButtons[selectedButtonIndex].isSelected = false
+        optionCardButtons[index].isSelected = true
+        selectedButtonIndex = index
+    }
+
+    /// index에 해당하는 옵션 카드의 view를 업데이트
+    func updateView(index: Int, with cardInfo: OptionCardInfo) {
+        optionCardButtons[index].setOptionTitle(cardInfo.title)
+        optionCardButtons[index].setOptionSubTitle(cardInfo.subTitle)
+        optionCardButtons[index].setPrice(cardInfo.priceString)
+    }
+
+    /// 카드 info에 따라 모든 옵션 카드의 view를 업데이트
+    func updateAllViews(with cardInfos: [OptionCardInfo]) {
+        optionCardButtons.enumerated().forEach { (index, _) in
+            updateView(index: index, with: cardInfos[index])
+        }
+    }
+}

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoMoreInfoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoMoreInfoOptionCardButtonView.swift
@@ -24,3 +24,10 @@ final class TwoMoreInfoOptionCardButtonView: TwoOptionCardButtonView {
         }
     }
 }
+
+extension TwoMoreInfoOptionCardButtonView: MoreInfoOptionButtonDelegate {
+    func moreInfoButtonDidTapped() {
+        print(#function)
+        // show alert
+    }
+}

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoMoreInfoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoMoreInfoOptionCardButtonView.swift
@@ -1,0 +1,26 @@
+//
+//  TwoMoreInfoOptionCardButtonView.swift
+//  iOS_H3
+//
+//  Created by  sangyeon on 2023/08/08.
+//
+
+import UIKit
+
+final class TwoMoreInfoOptionCardButtonView: TwoOptionCardButtonView {
+
+    convenience init(type: OptionCardButton.OptionCardType) {
+        let buttons = (0..<2).map { _ in MoreInfoOptionButton(type: type) }
+        self.init(button1: buttons[0], button2: buttons[1])
+        setupMoreInfoOptionButtonDelegate()
+    }
+
+    private func setupMoreInfoOptionButtonDelegate() {
+        optionCardButtons.forEach { button in
+            guard let moreInfoButton = button as? MoreInfoOptionButton else {
+                return
+            }
+            moreInfoButton.delegate = self
+        }
+    }
+}

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
@@ -56,7 +56,7 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
 extension TwoOptionCardButtonView: MoreInfoOptionButtonDelegate {
 
-    func moreInfoButtonPressed() {
+    func moreInfoButtonDidTapped() {
         print(#function)
         // show alert
     }

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
+class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     enum Constants {
         static let buttonSpacing = 12.0
@@ -23,12 +23,13 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     // MARK: - LifeCycles
 
-    init(frame: CGRect = .zero, type: OptionCardButton.OptionCardType, hasMoreInfo: Bool = false) {
-        if hasMoreInfo {
-            optionCardButtons = (0..<2).map { _ in MoreInfoOptionButton(type: type) }
-        } else {
-            optionCardButtons = (0..<2).map { _ in OptionCardButton(type: type) }
-        }
+    convenience init(type: OptionCardButton.OptionCardType) {
+        let buttons = (0..<2).map { _ in OptionCardButton(type: type) }
+        self.init(button1: buttons[0], button2: buttons[1])
+    }
+
+    init(frame: CGRect = .zero, button1: OptionCardButton, button2: OptionCardButton) {
+        optionCardButtons = [button1, button2]
         super.init(frame: frame)
 
         setupOptionCardButtons()

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
@@ -23,8 +23,12 @@ final class TwoOptionCardButtonView: UIView {
 
     // MARK: - LifeCycles
 
-    init(frame: CGRect = .zero, type: OptionCardButton.OptionCardType) {
-        optionCardButtons = (0..<2).map { _ in OptionCardButton(type: type) }
+    init(frame: CGRect = .zero, type: OptionCardButton.OptionCardType, hasMoreInfo: Bool = false) {
+        if hasMoreInfo {
+            optionCardButtons = (0..<2).map { _ in MoreInfoOptionButton(type: type) }
+        } else {
+            optionCardButtons = (0..<2).map { _ in OptionCardButton(type: type) }
+        }
         super.init(frame: frame)
 
         setupOptionCardButtons()
@@ -77,6 +81,13 @@ extension TwoOptionCardButtonView {
             button.translatesAutoresizingMaskIntoConstraints = false
             button.addTarget(self, action: #selector(optionCardButtonDidTapped(_:)), for: .touchUpInside)
         }
+
+        optionCardButtons.forEach { button in
+            guard let moreInfoButton = button as? MoreInfoOptionButton else {
+                return
+            }
+            moreInfoButton.delegate = self
+        }
     }
 
     private func setupViews() {
@@ -118,5 +129,13 @@ extension TwoOptionCardButtonView {
             optionCardButtons[1].trailingAnchor.constraint(equalTo: self.trailingAnchor),
             optionCardButtons[1].bottomAnchor.constraint(equalTo: self.optionCardButtons[0].bottomAnchor)
         ])
+    }
+}
+
+extension TwoOptionCardButtonView: MoreInfoOptionButtonDelegate {
+
+    func moreInfoButtonPressed() {
+        print(#function)
+        // show alert
     }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
@@ -1,0 +1,122 @@
+//
+//  TwoOptionCardButtonView.swift
+//  iOS_H3
+//
+//  Created by  sangyeon on 2023/08/07.
+//
+
+import UIKit
+
+final class TwoOptionCardButtonView: UIView {
+
+    enum Constants {
+        static let buttonSpacing = 12.0
+    }
+
+    // MARK: - UI Properties
+
+    private let optionCardButtons: [OptionCardButton]
+
+    // MARK: - Properties
+
+    private var selectedButtonIndex = 0
+
+    // MARK: - LifeCycles
+
+    init(frame: CGRect = .zero, type: OptionCardButton.OptionCardType) {
+        optionCardButtons = (0..<2).map { _ in OptionCardButton(type: type) }
+        super.init(frame: frame)
+
+        setupOptionCardButtons()
+        setupViews()
+    }
+
+    override init(frame: CGRect) {
+        optionCardButtons = (0..<2).map { _ in OptionCardButton(type: .selfMode) }
+        super.init(frame: frame)
+
+        setupOptionCardButtons()
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        optionCardButtons = (0..<2).map { _ in OptionCardButton(type: .selfMode) }
+        super.init(coder: coder)
+
+        setupOptionCardButtons()
+        setupViews()
+    }
+
+    // MARK: - Helpers
+
+    func selectOption(index: Int) {
+        optionCardButtons[selectedButtonIndex].isSelected = false
+        optionCardButtons[index].isSelected = true
+        selectedButtonIndex = index
+    }
+
+    /// index에 해당하는 옵션 카드의 view를 업데이트
+    func updateView(index: Int, with cardInfo: OptionCardInfo) {
+        optionCardButtons[index].setOptionTitle(cardInfo.title)
+        optionCardButtons[index].setOptionSubTitle(cardInfo.subTitle)
+        optionCardButtons[index].setPrice(cardInfo.priceString)
+    }
+
+    /// 카드 info에 따라 모든 옵션 카드의 view를 업데이트
+    func updateAllViews(with cardInfos: [OptionCardInfo]) {
+        optionCardButtons.enumerated().forEach { (index, _) in
+            updateView(index: index, with: cardInfos[index])
+        }
+    }
+}
+
+extension TwoOptionCardButtonView {
+
+    private func setupOptionCardButtons() {
+        optionCardButtons.forEach { button in
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.addTarget(self, action: #selector(optionCardButtonDidTapped(_:)), for: .touchUpInside)
+        }
+    }
+
+    private func setupViews() {
+        addSubviews()
+        setupConstraints()
+        selectOption(index: selectedButtonIndex)
+    }
+
+    @objc
+    private func optionCardButtonDidTapped(_ sender: UIButton) {
+        guard let selectedOptionIndex = optionCardButtons.firstIndex(where: { $0 == sender }) else {
+            return
+        }
+        selectOption(index: selectedOptionIndex)
+    }
+
+    private func addSubviews() {
+        optionCardButtons.forEach {
+            addSubview($0)
+        }
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            optionCardButtons[0].topAnchor.constraint(equalTo: self.topAnchor),
+            optionCardButtons[0].leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            optionCardButtons[0].trailingAnchor.constraint(
+                equalTo: self.centerXAnchor,
+                constant: -(Constants.buttonSpacing / 2)
+            ),
+            optionCardButtons[0].bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+        NSLayoutConstraint.activate([
+            optionCardButtons[1].topAnchor.constraint(equalTo: optionCardButtons[0].topAnchor),
+            optionCardButtons[1].leadingAnchor.constraint(
+                equalTo: self.centerXAnchor,
+                constant: (Constants.buttonSpacing / 2)
+            ),
+            optionCardButtons[1].trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            optionCardButtons[1].bottomAnchor.constraint(equalTo: self.optionCardButtons[0].bottomAnchor)
+        ])
+    }
+}

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
@@ -55,27 +55,12 @@ class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
     // MARK: - Helpers
 }
 
-extension TwoOptionCardButtonView: MoreInfoOptionButtonDelegate {
-
-    func moreInfoButtonDidTapped() {
-        print(#function)
-        // show alert
-    }
-}
-
 extension TwoOptionCardButtonView {
 
     private func setupOptionCardButtons() {
         optionCardButtons.forEach { button in
             button.translatesAutoresizingMaskIntoConstraints = false
             button.addTarget(self, action: #selector(optionCardButtonDidTapped(_:)), for: .touchUpInside)
-        }
-
-        optionCardButtons.forEach { button in
-            guard let moreInfoButton = button as? MoreInfoOptionButton else {
-                return
-            }
-            moreInfoButton.delegate = self
         }
     }
 

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class TwoOptionCardButtonView: UIView {
+final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     enum Constants {
         static let buttonSpacing = 12.0
@@ -15,11 +15,11 @@ final class TwoOptionCardButtonView: UIView {
 
     // MARK: - UI Properties
 
-    private let optionCardButtons: [OptionCardButton]
+    private(set) var optionCardButtons: [OptionCardButton]
 
     // MARK: - Properties
 
-    private var selectedButtonIndex = 0
+    var selectedButtonIndex = 0
 
     // MARK: - LifeCycles
 
@@ -52,25 +52,13 @@ final class TwoOptionCardButtonView: UIView {
     }
 
     // MARK: - Helpers
+}
 
-    func selectOption(index: Int) {
-        optionCardButtons[selectedButtonIndex].isSelected = false
-        optionCardButtons[index].isSelected = true
-        selectedButtonIndex = index
-    }
+extension TwoOptionCardButtonView: MoreInfoOptionButtonDelegate {
 
-    /// index에 해당하는 옵션 카드의 view를 업데이트
-    func updateView(index: Int, with cardInfo: OptionCardInfo) {
-        optionCardButtons[index].setOptionTitle(cardInfo.title)
-        optionCardButtons[index].setOptionSubTitle(cardInfo.subTitle)
-        optionCardButtons[index].setPrice(cardInfo.priceString)
-    }
-
-    /// 카드 info에 따라 모든 옵션 카드의 view를 업데이트
-    func updateAllViews(with cardInfos: [OptionCardInfo]) {
-        optionCardButtons.enumerated().forEach { (index, _) in
-            updateView(index: index, with: cardInfos[index])
-        }
+    func moreInfoButtonPressed() {
+        print(#function)
+        // show alert
     }
 }
 
@@ -129,13 +117,5 @@ extension TwoOptionCardButtonView {
             optionCardButtons[1].trailingAnchor.constraint(equalTo: self.trailingAnchor),
             optionCardButtons[1].bottomAnchor.constraint(equalTo: self.optionCardButtons[0].bottomAnchor)
         ])
-    }
-}
-
-extension TwoOptionCardButtonView: MoreInfoOptionButtonDelegate {
-
-    func moreInfoButtonPressed() {
-        print(#function)
-        // show alert
     }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonViewController.swift
@@ -1,0 +1,106 @@
+//
+//  TwoOptionCardButtonViewController.swift
+//  iOS_H3
+//
+//  Created by  sangyeon on 2023/08/07.
+//
+
+import UIKit
+
+final class TwoOptionCardButtonViewController: UIViewController {
+
+    // MARK: - UI properties
+
+    private let selfModeTwoOptionCardButtonView: TwoOptionCardButtonView = {
+        let view = TwoOptionCardButtonView(type: .selfMode)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let guideModeTwoOptionCardButtonView: TwoOptionCardButtonView = {
+        let view = TwoOptionCardButtonView(type: .guideMode)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let twoOptionCardButtonViewWithData: TwoOptionCardButtonView = {
+        let view = TwoOptionCardButtonView(type: .selfMode)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let cardInfos: [OptionCardInfo] = [
+            .init(title: "디젤 2.2", subTitle: "구매자의 63%가 선택한", priceString: "+ 1,480,000원"),
+            .init(title: "가솔린 3.8", subTitle: "구매자의 37%가 선택한", priceString: "+ 0원")
+        ]
+        view.updateAllViews(with: cardInfos)
+        return view
+    }()
+
+    // MARK: - Lifecycles
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupViews()
+    }
+
+    // MARK: - Helpers
+
+    private func setupViews() {
+        view.backgroundColor = .white
+        addSubviews()
+        setupConstraints()
+    }
+
+    private func addSubviews() {
+        view.addSubview(selfModeTwoOptionCardButtonView)
+        view.addSubview(guideModeTwoOptionCardButtonView)
+        view.addSubview(twoOptionCardButtonViewWithData)
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            selfModeTwoOptionCardButtonView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: 10
+            ),
+            selfModeTwoOptionCardButtonView.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                constant: 16
+            ),
+            selfModeTwoOptionCardButtonView.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                constant: -16
+            ),
+            selfModeTwoOptionCardButtonView.heightAnchor.constraint(equalToConstant: 150)
+        ])
+        NSLayoutConstraint.activate([
+            guideModeTwoOptionCardButtonView.topAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.bottomAnchor,
+                constant: 10
+            ),
+            guideModeTwoOptionCardButtonView.leadingAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.leadingAnchor
+            ),
+            guideModeTwoOptionCardButtonView.trailingAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.trailingAnchor
+            ),
+            guideModeTwoOptionCardButtonView.heightAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.heightAnchor
+            )
+        ])
+        NSLayoutConstraint.activate([
+            twoOptionCardButtonViewWithData.topAnchor.constraint(
+                equalTo: guideModeTwoOptionCardButtonView.bottomAnchor,
+                constant: 10
+            ),
+            twoOptionCardButtonViewWithData.leadingAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.leadingAnchor
+            ),
+            twoOptionCardButtonViewWithData.trailingAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.trailingAnchor
+            ),
+            twoOptionCardButtonViewWithData.heightAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.heightAnchor
+            )
+        ])
+    }
+}

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonViewController.swift
@@ -34,6 +34,12 @@ final class TwoOptionCardButtonViewController: UIViewController {
         return view
     }()
 
+    private let moreInfoTwoOptionCardButtonView: TwoOptionCardButtonView = {
+        let view = TwoOptionCardButtonView(type: .selfMode, hasMoreInfo: true)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     // MARK: - Lifecycles
 
     override func viewDidLoad() {
@@ -54,9 +60,17 @@ final class TwoOptionCardButtonViewController: UIViewController {
         view.addSubview(selfModeTwoOptionCardButtonView)
         view.addSubview(guideModeTwoOptionCardButtonView)
         view.addSubview(twoOptionCardButtonViewWithData)
+        view.addSubview(moreInfoTwoOptionCardButtonView)
     }
 
     private func setupConstraints() {
+        setupSelfModeTwoOptionCardButtonViewConstraints()
+        setupGuideModeTwoOptionCardButtonViewConstraints()
+        setupTwoOptionCardButtonViewWithDataConstraints()
+        setupMoreInfoTwoOptionCardButtonViewConstraints()
+    }
+
+    private func setupSelfModeTwoOptionCardButtonViewConstraints() {
         NSLayoutConstraint.activate([
             selfModeTwoOptionCardButtonView.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor,
@@ -72,6 +86,9 @@ final class TwoOptionCardButtonViewController: UIViewController {
             ),
             selfModeTwoOptionCardButtonView.heightAnchor.constraint(equalToConstant: 150)
         ])
+    }
+
+    private func setupGuideModeTwoOptionCardButtonViewConstraints() {
         NSLayoutConstraint.activate([
             guideModeTwoOptionCardButtonView.topAnchor.constraint(
                 equalTo: selfModeTwoOptionCardButtonView.bottomAnchor,
@@ -87,6 +104,9 @@ final class TwoOptionCardButtonViewController: UIViewController {
                 equalTo: selfModeTwoOptionCardButtonView.heightAnchor
             )
         ])
+    }
+
+    private func setupTwoOptionCardButtonViewWithDataConstraints() {
         NSLayoutConstraint.activate([
             twoOptionCardButtonViewWithData.topAnchor.constraint(
                 equalTo: guideModeTwoOptionCardButtonView.bottomAnchor,
@@ -99,6 +119,24 @@ final class TwoOptionCardButtonViewController: UIViewController {
                 equalTo: selfModeTwoOptionCardButtonView.trailingAnchor
             ),
             twoOptionCardButtonViewWithData.heightAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.heightAnchor
+            )
+        ])
+    }
+
+    private func setupMoreInfoTwoOptionCardButtonViewConstraints() {
+        NSLayoutConstraint.activate([
+            moreInfoTwoOptionCardButtonView.topAnchor.constraint(
+                equalTo: twoOptionCardButtonViewWithData.bottomAnchor,
+                constant: 10
+            ),
+            moreInfoTwoOptionCardButtonView.leadingAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.leadingAnchor
+            ),
+            moreInfoTwoOptionCardButtonView.trailingAnchor.constraint(
+                equalTo: selfModeTwoOptionCardButtonView.trailingAnchor
+            ),
+            moreInfoTwoOptionCardButtonView.heightAnchor.constraint(
                 equalTo: selfModeTwoOptionCardButtonView.heightAnchor
             )
         ])

--- a/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/TwoOptionCardButtonViewController.swift
@@ -35,7 +35,7 @@ final class TwoOptionCardButtonViewController: UIViewController {
     }()
 
     private let moreInfoTwoOptionCardButtonView: TwoOptionCardButtonView = {
-        let view = TwoOptionCardButtonView(type: .selfMode, hasMoreInfo: true)
+        let view = TwoMoreInfoOptionCardButtonView(type: .selfMode)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()


### PR DESCRIPTION
## 🔖 관련 이슈
- #23 

## 📝 구현 사항

### OptionCardInfo 모델 구현

- 옵션 카드 업데이트 시 사용할 OptionCardInfo 모델을 구현했습니다.
- 프로퍼티 구성 : title, subTitle, priceString

### OptionCardButtonListViewable 프로토콜 구현

구현 이유 : 특정 인덱스의 옵션 카드 버튼을 선택해주는 `selectOption(index:)` 메소드와 
전달받은 옵션 정보에 따라 index의 버튼 뷰를 업데이트 해주는 `updateView(index:,with:)` 메소드,
전달받은 옵션 정보에 따라 모든 view를 업데이트 해주는 `updateAllViews(with:)` 메소드는

추후 멀티 옵션카드버튼 뷰가 생겼을 때에도 동일하게 적용되는 로직일 것 같아서
채택해서 사용할 수 있도록 구현해주었습니다.

### TwoOptionCardButtonView 구현

- type (셀프모드 혹은 가이드모드)과 hasMoreInfo (자세히보기 버튼 유무) 여부에 따라 인스턴스 생성
- 한 버튼 클릭 시 해당 버튼을 선택하고 다른 버튼은 선택 해제
- `updateAllViews(with:)` 이용하여 버튼 정보 업데이트 가능

셀프모드 | 가이드모드 | OptionCardInfo 전달하여 UI 업데이트 
---|---|---
<img width="313" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/0b88b80d-713f-43fd-885a-b1e1aa527319"> | <img width="304" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/93aa86e1-47a5-4d09-ab94-43bc8b6b8831"> | <img width="311" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/b8a552bd-e7cd-4a18-9e77-e7c388c879bb">

자세히보기 버튼 | 버튼 클릭 시
---|---
<img width="309" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/91f7a8ac-6481-40bb-868b-0408608bd481"> |  ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-08 at 13 51 02](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/aedb0a2d-cd75-40ff-8c2b-7c56d2e3845f)


### 기타

- OptionCardButton의 optionSubTitleLabel의 폰트 수정 (디자인 가이드에 따라 수정)
- OptionCardButton 내부의 label 프로퍼티들의 자간과 줄 간격 설정 추가
- OptionCardButton의 cornerRadius 값 수정 (10 -> 6)
- OptionCardButton를 상속받은 하위 클래스들 (이미지 옵션 버튼, 자세히보기 옵션 버튼, 컬러 옵션 버튼) 의 init 수정
  - 기존: super.init(type: type)
  - 수정: super.init(type: type, title: title, subTitle: subTitle, price: price)
  - 기존의 경우, 타이틀과 서브타이틀, price가 전달되지 않아서 항상 "옵션 타이틀" "옵션 서브 타이틀" "+ 0원"으로 초기화되는 문제가 있어서
     파라미터로 전달된 값으로 초기화 될 수 있도록 수정했습니다
- MoreIntoOptionButton에 터치 이벤트 추가

- 앱 번들아이디, 앱 표시 이름 수정

## 📌 하고싶은 말

### 객체지향 관련

`TwoOptionCardButtonView` 구현 시 
기본 OptionCardButton 외에 자세히보기 버튼(MoreInfoOptionCardButton)으로도 사용할 수 있어야 했습니다.

`OptionCardButton`을 이용했을 경우와 `MoreInfoOptionCardButton`을 이용했을 경우 모두
초기화 시 `TwoOptionCardButtonView`의 내부 프로퍼티인 `optionCardButtons`가 각 버튼 타입으로 초기화 된다는 것 이외에 레이아웃 구성이나 버튼 선택 시 액션은 동일합니다.

즉, init 내부에서 `optionCardButtons` 초기화만 달라지고 나머지` setupViews()`와 `setupOptionCardButtons()` 함수 호출은 동일합니다.
이 부분을 클래스 상속이나 프로토콜 채택 등을 통해 객체지향적으로 구현하고 싶었는데 아직 좋은 방법을 못찾았습니다 ㅠㅠ .. . .. .

현재 구현은 다음과 같습니다.

```swift
final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
    ....
    init(frame: CGRect = .zero, type: OptionCardButton.OptionCardType, hasMoreInfo: Bool = false) {
        if hasMoreInfo {
            optionCardButtons = (0..<2).map { _ in MoreInfoOptionButton(type: type) }
        } else {
            optionCardButtons = (0..<2).map { _ in OptionCardButton(type: type) }
        }
        super.init(frame: frame)

        setupOptionCardButtons()
        setupViews()
    }
    ...
}
```

TwoOptionCardButtonView 초기화 시 `hasMoreInfo` 값을 받아서 `true`이면 자세히보기 버튼으로 초기화하고 `false`이면 기본 옵션카드 버튼으로 초기화 해줬습니다.

그러나 이 경우, OCP에 위배되기 때문에 너무너무너무너무 아쉽습니다 .... 

일단 뒤에 구현이 급해서 이렇게 PR 날립니다 🙇‍♂️ 천천히 생각해보고 좋은게 생각나면 다시 수정해서 PR 쓰겠습니다
좋은 생각 있으시면 알려주세요 ~!