### PR TITLE
[FE] 메인 페이지 일부 UI 구현 및 라우팅

### DIFF
--- a/frontend/custom.d.ts
+++ b/frontend/custom.d.ts
@@ -1,0 +1,11 @@
+declare module '*.svg' {
+  import React = require('react');
+  export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  const src: string;
+  export default src;
+}
+
+declare module '*.png' {
+  const value: string;
+  export default value;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,8 @@
         "eslint-plugin-react-refresh": "^0.4.3",
         "prettier": "^3.0.0",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "vite": "^4.4.5",
+        "vite-plugin-svgr": "^3.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2495,6 +2496,237 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-7.0.0.tgz",
+      "integrity": "sha512-khWbXesWIP9v8HuKCl2NU2HNAyqpSQ/vkIl36Nbn4HIwEYSRWL0H7Gs6idJdha2DkpFDWlsqMELvoCE8lfFY6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-7.0.0.tgz",
+      "integrity": "sha512-iiZaIvb3H/c7d3TH2HBeK91uI2rMhZNwnsIrvd7ZwGLkFw6mmunOCoVnjdYua662MqGFxlN9xTq4fv9hgR4VXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-7.0.0.tgz",
+      "integrity": "sha512-sQQmyo+qegBx8DfFc04PFmIO1FP1MHI1/QEpzcIcclo5OAISsOJPW76ZIs0bDyO/DBSJEa/tDa1W26pVtt0FRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-7.0.0.tgz",
+      "integrity": "sha512-i6MaAqIZXDOJeikJuzocByBf8zO+meLwfQ/qMHIjCcvpnfvWf82PFvredEZElErB5glQFJa2KVKk8N2xV6tRRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-7.0.0.tgz",
+      "integrity": "sha512-BoVSh6ge3SLLpKC0pmmN9DFlqgFy4NxNgdZNLPNJWBUU7TQpDWeBuyVuDW88iXydb5Cv0ReC+ffa5h3VrKfk1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-7.0.0.tgz",
+      "integrity": "sha512-tNDcBa+hYn0gO+GkP/AuNKdVtMufVhU9fdzu+vUQsR18RIJ9RWe7h/pSBY338RO08wArntwbDk5WhQBmhf2PaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-7.0.0.tgz",
+      "integrity": "sha512-qw54u8ljCJYL2KtBOjI5z7Nzg8LnSvQOP5hPKj77H4VQL4+HdKbAT5pnkkZLmHKYwzsIHSYKXxHouD8zZamCFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-transform-svg-component": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-7.0.0.tgz",
+      "integrity": "sha512-CcFECkDj98daOg9jE3Bh3uyD9kzevCAnZ+UtzG6+BQG/jOQ2OA3jHnX6iG4G1MCJkUQFnUvEv33NvQfqrb/F3A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-preset": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-7.0.0.tgz",
+      "integrity": "sha512-EX/NHeFa30j5UjldQGVQikuuQNHUdGmbh9kEpBKofGUtF0GUPJ4T4rhoYiqDAOmBOxojyot36JIFiDUHUK1ilQ==",
+      "dev": true,
+      "dependencies": {
+        "@svgr/babel-plugin-add-jsx-attribute": "^7.0.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "^7.0.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "^7.0.0",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "^7.0.0",
+        "@svgr/babel-plugin-svg-dynamic-title": "^7.0.0",
+        "@svgr/babel-plugin-svg-em-dimensions": "^7.0.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "^7.0.0",
+        "@svgr/babel-plugin-transform-svg-component": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-ztAoxkaKhRVloa3XydohgQQCb0/8x9T63yXovpmHzKMkHO6pkjdsIAWKOS4bE95P/2quVh1NtjSKlMRNzSBffw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "^7.0.0",
+        "camelcase": "^6.2.0",
+        "cosmiconfig": "^8.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@svgr/hast-util-to-babel-ast": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-7.0.0.tgz",
+      "integrity": "sha512-42Ej9sDDEmsJKjrfQ1PHmiDiHagh/u9AHO9QWbeNx4KmD9yS5d1XHmXUNINfUcykAU+4431Cn+k6Vn5mWBYimQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.21.3",
+        "entities": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@svgr/plugin-jsx": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-7.0.0.tgz",
+      "integrity": "sha512-SWlTpPQmBUtLKxXWgpv8syzqIU8XgFRvyhfkam2So8b3BE0OS0HPe5UfmlJ2KIC+a7dpuuYovPR2WAQuSyMoPw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "^7.0.0",
+        "@svgr/hast-util-to-babel-ast": "^7.0.0",
+        "svg-parser": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -2535,6 +2767,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -3223,6 +3461,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/camelize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
@@ -3349,6 +3599,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
       }
     },
     "node_modules/cross-spawn": {
@@ -3521,6 +3789,27 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.22.1",
@@ -4237,6 +4526,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4759,6 +5054,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -5100,6 +5401,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5165,6 +5472,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -5582,6 +5895,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -6426,6 +6757,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+      "dev": true
+    },
     "node_modules/synckit": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -6774,6 +7111,20 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-svgr": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-3.2.0.tgz",
+      "integrity": "sha512-Uvq6niTvhqJU6ga78qLKBFJSDvxWhOnyfQSoKpDPMAGxJPo5S3+9hyjExE5YDj6Lpa4uaLkGc1cBgxXov+LjSw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.2",
+        "@svgr/core": "^7.0.0",
+        "@svgr/plugin-jsx": "^7.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.6.0 || 3 || 4"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-react-refresh": "^0.4.3",
     "prettier": "^3.0.0",
     "typescript": "^5.0.2",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "vite-plugin-svgr": "^3.2.0"
   }
 }

--- a/frontend/src/assets/icons/arrow_right.svg
+++ b/frontend/src/assets/icons/arrow_right.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<g id="Group">
+<path id="Vector" d="M10.9766 10.0006L6.85156 5.8756L8.0299 4.69727L13.3332 10.0006L8.0299 15.3039L6.85156 14.1256L10.9766 10.0006Z" fill="inherit"/>
+</g>
+</svg>

--- a/frontend/src/assets/icons/index.ts
+++ b/frontend/src/assets/icons/index.ts
@@ -1,0 +1,9 @@
+export {ReactComponent as ArrowRight} from './arrow_right.svg';
+export {ReactComponent as Car} from './car.svg';
+export {ReactComponent as Dictionary} from './dictionary.svg';
+export {ReactComponent as L} from './l.svg';
+export {ReactComponent as More1} from './more1.svg';
+export {ReactComponent as More2} from './more2.svg';
+export {ReactComponent as ProgressBar} from './progressBar.svg';
+export {ReactComponent as ProgressSelected} from './progress_selected.svg';
+export {ReactComponent as Selector} from './selector.svg';

--- a/frontend/src/assets/mocks/trim.json
+++ b/frontend/src/assets/mocks/trim.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": 1,
+    "name": "Guide Mode",
+    "tag": "나만을 위한 팰리세이드",
+    "price": 38960000,
+    "route": "/",
+    "description": {
+      "title": "나에게 딱맞는 구성으로,",
+      "hasDescription": true,
+      "descriptionData": [
+        {
+          "main": "내 관심 분야를 바탕으로 유형 분석",
+          "sub": "선택해주신 태그를 바탕으로 나의 유형을 분석해드려요."
+        },
+        {
+          "main": "개인맞춤 가이드와 함께 쉽게 옵션 선택!",
+          "sub": "나와 비슷한 유형의 사람들은 어떤 옵션을 선택했는지 알 수 있어요."
+        },
+        {
+          "main": "나만의 멋진 차 완성!",
+          "sub": "나의 취향이 반영된 멋진 차가 완성돼요!"
+        }
+      ]
+    }
+  },
+  {
+    "id": 2,
+    "name": "Exclusive",
+    "tag": "기본에 충실",
+    "price": 40440000,
+    "route": "/",
+    "description": null
+  },
+  {
+    "id": 3,
+    "name": "Le Blanc",
+    "tag": "베스트셀러",
+    "price": 43460000,
+    "route": "/self",
+    "description": {
+      "title": "모두가 선택한 베스트셀러",
+      "hasDescription": false,
+      "descriptionData": [
+        {
+          "main": "20인치\n알로이 휠",
+          "sub": "src/asset/images/le_blanc_option1.png"
+        },
+        {
+          "main": "서라운드 뷰\n모니터",
+          "sub": "src/asset/images/le_blanc_option2.png"
+        },
+        {
+          "main": "클러스터\n(12.3인치 컬러 LCD)",
+          "sub": "src/asset/images/le_blanc_option3.png"
+        }
+      ]
+    }
+  },
+  {
+    "id": 4,
+    "name": "Prestige",
+    "tag": "부담없는 고급감",
+    "price": 47720000,
+    "route": "/",
+    "description": null
+  },
+  {
+    "id": 5,
+    "name": "Calligraphy",
+    "tag": "최고를 원한다면",
+    "price": 52540000,
+    "route": "/",
+    "description": null
+  }
+]

--- a/frontend/src/component/common/icons.tsx
+++ b/frontend/src/component/common/icons.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import styled from 'styled-components';
+import * as icons from '@/assets/icons';
+
+type IconType = keyof typeof icons;
 interface IconProps {
-  name: string;
+  name: IconType;
   size: number;
 }
-function Icon({name, size}: IconProps) {
-  return (
-    <IconImg
-      src={`../src/assets/icons/${name}.svg`}
-      width={size}
-      height={size}
-    ></IconImg>
-  );
-}
 
+function Icon({name, size}: IconProps) {
+  const Icon = icons[name];
+  return <Icon width={size} height={size} />;
+}
 export default Icon;
-const IconImg = styled.img``;

--- a/frontend/src/component/content/right/card/OptionCard.tsx
+++ b/frontend/src/component/content/right/card/OptionCard.tsx
@@ -50,7 +50,11 @@ function OptionCard() {
       <Text1>구매자의 63%가 선택했어요!</Text1>
       <Text2>디젤 2.2</Text2>
       <DetailBox ref={contentBoxRef} toggle={toggle}>
-        <DetailContent ref={contentRef}>컨텐츠</DetailContent>
+        <DetailContent ref={contentRef}>
+          컨텐츠컨텐츠컨텐츠컨텐츠컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠
+          컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠
+          컨텐츠 컨텐츠 컨텐츠 컨텐츠 컨텐츠
+        </DetailContent>
       </DetailBox>
       <Footer>
         <Price>+ 1,480,000원</Price>

--- a/frontend/src/component/header/Header.tsx
+++ b/frontend/src/component/header/Header.tsx
@@ -22,8 +22,6 @@ const Wrapper = styled.div`
 `;
 
 const Content = styled.div`
-  width: 100%;
+  width: 1024px;
   ${flexBetween};
-  margin-left: 128px;
-  margin-right: 127px;
 `;

--- a/frontend/src/component/main/MainContainer.tsx
+++ b/frontend/src/component/main/MainContainer.tsx
@@ -23,9 +23,9 @@ function MainContainer() {
         <ShowMore.Wrapper>
           <ShowMore.Text>자세한 설명과 비교를 원한다면</ShowMore.Text>
           <ShowMore.IconWrapper>
-            <Icon name={'more1'} size={26} />
+            <Icon name="More1" size={26} />
             <ShowMore.Abs>
-              <Icon name={'more2'} size={26} />
+              <Icon name="More2" size={26} />
             </ShowMore.Abs>
           </ShowMore.IconWrapper>
         </ShowMore.Wrapper>
@@ -44,9 +44,9 @@ const Main = {
     width: 100%;
   `,
   Content: styled.div`
-    width: 100%;
+    width: 1024px;
     height: 100%;
-    padding: 85px 128px 0 128px;
+    padding-top: 85px;
     display: flex;
     flex-direction: column;
   `,
@@ -70,13 +70,15 @@ const Title = {
     font-size: 64px;
     font-style: normal;
     font-weight: 500;
-    line-height: 88%;
+    line-height: 130%;
   `,
 };
 
 const TrimCardWrapper = styled.div`
   margin-top: auto;
   margin-bottom: 40px;
+  display: flex;
+  gap: 16px;
 `;
 
 const ShowMore = {

--- a/frontend/src/component/main/trimCard/TrimCard.tsx
+++ b/frontend/src/component/main/trimCard/TrimCard.tsx
@@ -1,19 +1,105 @@
+import Icon from '@/component/common/icons';
+import {flexBetween} from '@/style/common';
+import {Body2_Regular, Title2_Medium} from '@/style/fonts';
 import {colors} from '@/style/theme';
-import React from 'react';
+import React, {useState} from 'react';
 import {styled} from 'styled-components';
-function TrimCard() {
-  return <Card.Wrapper></Card.Wrapper>;
+
+import trim from '@/assets/mocks/trim.json';
+import TrimDescription from './trimDescription/TrimDescription';
+
+type TrimData = {
+  id: number;
+  name: string;
+  tag: string;
+  price: number;
+  route: string;
+  description?: {
+    title: string;
+    hasDescription: boolean;
+    descriptionData: Array<{
+      main: string;
+      sub: string;
+    }>;
+  } | null;
+};
+
+export interface TrimCardProps {
+  trimData: TrimData;
+}
+function TrimCard({trimData}: TrimCardProps) {
+  const [isHover, setIsHover] = useState<boolean>(false);
+  return (
+    <>
+      <Card.Wrapper
+        onMouseEnter={() => setIsHover(true)}
+        onMouseLeave={() => setIsHover(false)}
+      >
+        <Card.Tag>{`#${trimData.tag}`}</Card.Tag>
+        <Card.Name>{`${trimData.name}`}</Card.Name>
+        <Card.PriceWrapper>
+          <Card.Price>{`${trimData.price.toLocaleString()}원 부터`}</Card.Price>
+          <Icon name="ArrowRight" size={20} />
+        </Card.PriceWrapper>
+        {isHover && (
+          <>
+            {trimData.description && (
+              <TrimDescription trimDescription={trimData.description} />
+            )}
+          </>
+        )}
+      </Card.Wrapper>
+    </>
+  );
+}
+function TrimCardList() {
+  return (
+    <>
+      {trim.map((trimItem) => (
+        <TrimCard key={trimItem.id} trimData={trimItem} />
+      ))}
+    </>
+  );
 }
 
-export default TrimCard;
+export default TrimCardList;
+
 const Card = {
   Wrapper: styled.div`
+    position: relative;
     width: 192px;
     height: 123px;
     border-radius: 6px;
     background: ${colors.Hyundai_White};
+    color: ${colors.Cool_Grey};
     flex-shrink: 0;
     backdrop-filter: blur(12px);
-    padding: 20px;
+    padding: 20px 14px 20px 20px;
+    cursor: pointer;
+
+    transition: all 0.1s;
+
+    &:hover {
+      color: white;
+      background-color: ${colors.Main_Hyundai_Blue};
+
+      & svg {
+        fill: white;
+      }
+    }
+  `,
+  Tag: styled.p`
+    ${Body2_Regular}
+    margin-bottom : 8px;
+  `,
+  Name: styled.p`
+    ${Title2_Medium}
+    margin-bottom : 17px;
+  `,
+  PriceWrapper: styled.div`
+    ${flexBetween}
+  `,
+  Price: styled.p`
+    ${Body2_Regular}
   `,
 };

--- a/frontend/src/component/main/trimCard/TrimCard.tsx
+++ b/frontend/src/component/main/trimCard/TrimCard.tsx
@@ -4,6 +4,7 @@ import {Body2_Regular, Title2_Medium} from '@/style/fonts';
 import {colors} from '@/style/theme';
 import React, {useState} from 'react';
 import {styled} from 'styled-components';
+import {useNavigate} from 'react-router-dom';
 
 import trim from '@/assets/mocks/trim.json';
 import TrimDescription from './trimDescription/TrimDescription';
@@ -28,12 +29,18 @@ export interface TrimCardProps {
   trimData: TrimData;
 }
 function TrimCard({trimData}: TrimCardProps) {
+  const navigate = useNavigate();
   const [isHover, setIsHover] = useState<boolean>(false);
+
+  const handleTrimCardClick = (route: string) => {
+    navigate(route);
+  };
   return (
     <>
       <Card.Wrapper
         onMouseEnter={() => setIsHover(true)}
         onMouseLeave={() => setIsHover(false)}
+        onClick={() => handleTrimCardClick(trimData.route)}
       >
         <Card.Tag>{`#${trimData.tag}`}</Card.Tag>
         <Card.Name>{`${trimData.name}`}</Card.Name>

--- a/frontend/src/component/main/trimCard/trimDescription/TrimDescription.tsx
+++ b/frontend/src/component/main/trimCard/trimDescription/TrimDescription.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from 'styled-components';
+type TrimDescriptionData = {
+  title: string;
+  hasDescription: boolean;
+  descriptionData: Array<{
+    main: string;
+    sub: string;
+  }>;
+} | null;
+
+export interface TrimDescriptionProps {
+  trimDescription: TrimDescriptionData;
+}
+function TrimDescription({trimDescription}: TrimDescriptionProps) {
+  return <Description.Wrapper></Description.Wrapper>;
+}
+
+export default TrimDescription;
+
+const Description = {
+  Wrapper: styled.div`
+    position: absolute;
+    top: -253px;
+    left: 0;
+    padding: 37px 26px 37px 33px;
+    border-radius: 6px;
+    width: 609px;
+    height: 237px;
+    background: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.2) 0%,
+      rgba(255, 255, 255, 0) 100%
+    );
+    justify-content: flex-end;
+    align-items: center;
+    gap: 50px;
+    backdrop-filter: blur(6px);
+  `,
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,8 +3,8 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import GlobalStyle from './style/global.tsx';
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <>
     <GlobalStyle />
     <App />
-  </React.StrictMode>,
+  </>,
 );

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,5 +12,6 @@
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
     "paths": {"@/*": ["src/*"]}
-  }
+  },
+  "include": ["src", "custom.d.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,11 @@
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import svgr from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), svgr()],
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## 🔖 관련 이슈
- #60

## 📝 구현 사항
- 메인페이지 일부 구현했습니다. 카드 hover 시 안에 상세설명 보여주도록 할 예정입니다. 
<img width="1021" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/15906101/87309ac7-6486-4b15-9188-d153e5122566">

- 메인페이지 trim 설명 이일단 mock data로 보여주고 있습니다. 나중에 api 연결해야해요~~~
```
[
  {
    "id": 1,
    "name": "Guide Mode",
    "tag": "나만을 위한 팰리세이드",
    "price": 38960000,
    "route": "/",
    "description": {
      "title": "나에게 딱맞는 구성으로,",
      "hasDescription": true,
      "descriptionData": [
        {
          "main": "내 관심 분야를 바탕으로 유형 분석",
          "sub": "선택해주신 태그를 바탕으로 나의 유형을 분석해드려요."
        },
        {
          "main": "개인맞춤 가이드와 함께 쉽게 옵션 선택!",
          "sub": "나와 비슷한 유형의 사람들은 어떤 옵션을 선택했는지 알 수 있어요."
        },
        {
          "main": "나만의 멋진 차 완성!",
          "sub": "나의 취향이 반영된 멋진 차가 완성돼요!"
        }
      ]
    },
   ...
]
```
## 📌 하고싶은 말
- 같은 파트원에게 하고싶은 말
