### PR TITLE
[FE] 이미지 전환 애니메이션, 옵션 카드 스크롤 뷰 구현

### DIFF
--- a/frontend/src/component/content/Content.tsx
+++ b/frontend/src/component/content/Content.tsx
@@ -63,6 +63,7 @@ function Content() {
             />
             <OptionInfo
               cardData={cardData}
+              option={option}
               setNewIndex={(index: number) => setNewIndex(index)}
             />
           </>

--- a/frontend/src/component/content/left/OptionImage.tsx
+++ b/frontend/src/component/content/left/OptionImage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useRef} from 'react';
 import styled, {css, keyframes} from 'styled-components';
 import {flexCenter} from '../../../style/common';
 import {cardDataType} from '../contentInterface';
@@ -10,7 +10,7 @@ interface ImageProps {
 
 const growAnimation = keyframes`
   0% {
-    clip-path: polygon(0% 0%, 100% 0%, 100% 0%, 0% 0%);
+    clip-path: polygon(0% 0%, 0% 0%, 0% 100%, 0% 100%);
   }
   100% {
     clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
@@ -20,7 +20,6 @@ const growAnimation = keyframes`
 function OptionImage({cardData, selectedIndex}: ImageProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const prevRef = useRef<number | undefined>(undefined);
-
   const imgBox = wrapperRef.current?.childNodes[selectedIndex];
 
   if (imgBox instanceof HTMLElement) {
@@ -66,7 +65,7 @@ function OptionImage({cardData, selectedIndex}: ImageProps) {
 
 export default OptionImage;
 
-const Wrapper = styled.div<{$currheight: number | undefined}>`
+const Wrapper = styled.div<{$currheight?: number}>`
   flex: 6;
 `;
 
@@ -87,7 +86,7 @@ const ImageBox = styled.div<{$isActive: boolean}>`
   ${({$isActive}) =>
     $isActive &&
     css`
-      animation: ${growAnimation} 0.75s both;
+      animation: ${growAnimation} 0.5s both cubic-bezier(1, 0, 0.5, 1);
       animation-delay: 0.2s;
     `}
 `;

--- a/frontend/src/component/content/right/OptionCardList.tsx
+++ b/frontend/src/component/content/right/OptionCardList.tsx
@@ -24,8 +24,28 @@ const moveTop = keyframes`
   }
 `;
 
+const scrollIntoSelected = (
+  elem: React.RefObject<HTMLUListElement>,
+  index: number,
+) => {
+  const scrollBlock: ScrollIntoViewOptions = {
+    behavior: 'smooth',
+    block: 'center',
+  };
+
+  if (elem && elem.current) {
+    const scrollItem = elem.current.childNodes[index] as HTMLElement;
+
+    if (elem.current.lastChild === scrollItem) {
+      scrollBlock.block = 'end';
+    }
+
+    scrollItem.scrollIntoView(scrollBlock);
+  }
+};
+
 function OptionCardList({cardData, setNewIndex}: carfListProps) {
-  const [selectedItem, setSelectedItem] = useState<number | null>(0);
+  const [selectedItem, setSelectedItem] = useState<number>(0);
   const {option} = useContext(OptionContext);
   const ulRef = useRef<HTMLUListElement>(null);
 
@@ -37,6 +57,10 @@ function OptionCardList({cardData, setNewIndex}: carfListProps) {
   useEffect(() => {
     setSelectedItem(0);
   }, [cardData]);
+
+  useEffect(() => {
+    scrollIntoSelected(ulRef, selectedItem);
+  }, [selectedItem]);
 
   const cards: React.JSX.Element[] = cardData.map((elem, index) => (
     <OptionCard
@@ -75,8 +99,9 @@ const Container = styled.ul`
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
+  margin-bottom: 30px;
   width: 100%;
-  max-height: 485px;
-  animation: ${moveTop} 1s ease-out;
+
+  // animation: ${moveTop} 1s ease-out;
   gap: 16px;
 `;

--- a/frontend/src/component/content/right/OptionInfo.tsx
+++ b/frontend/src/component/content/right/OptionInfo.tsx
@@ -17,11 +17,22 @@ interface Data {
 
 interface cardDataProps {
   cardData: cardDataType[];
+  option: number;
   setNewIndex: (index: number) => void;
 }
 
-function OptionInfo({cardData, setNewIndex}: cardDataProps) {
+function OptionInfo({cardData, setNewIndex, option}: cardDataProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const menuItems = [
+    '파워트레인',
+    '구동 방식',
+    '바디 타입',
+    '외장 색상',
+    '내장 색상',
+    '휠',
+    '옵션',
+  ];
 
   const modalRef = useRef<HTMLDivElement>(null);
   const handleModalView = useCallback(() => {
@@ -31,7 +42,7 @@ function OptionInfo({cardData, setNewIndex}: cardDataProps) {
   return (
     <Wrapper>
       <Container>
-        <OptionTitle>파워트레인</OptionTitle>
+        <OptionTitle>{menuItems[option]}</OptionTitle>
         <Text>을 선택해주세요.</Text>
         <OptionCardList
           cardData={cardData}


### PR DESCRIPTION
## PR 작성 전 체크 리스트
- PR 제목: `[파트이름] 구현사항 어쩌구 저쩌구` (예: `[FE] Login page UI 구현` )
- PR 작성 후 충돌이 안 나는지 확인, merge후 branch 삭제
- 고민사항은 공유하기
- 위 사항 확인 후 내용 지우기~~

## 🔖 관련 이슈
- #97 ( #이슈번호 )

## 📝 구현 사항
- 이미지 전환 애니메이션 구현
- 옵션 카드 클릭 스크롤 뷰 구현
![ezgif com-video-to-gif (5)](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/97653343/1bdf8cb0-4ef4-40ed-9329-44d077f30a7b)

## 고민했던 내용
```js
const scrollIntoSelected = (
  elem: React.RefObject<HTMLUListElement>,
  index: number,
) => {
  const scrollBlock: ScrollIntoViewOptions = {
    behavior: 'smooth',
    block: 'center',
  };

  if (elem && elem.current) {
    const scrollItem = elem.current.childNodes[index] as HTMLElement;

    if (elem.current.lastChild === scrollItem) {
      scrollBlock.block = 'end';
    }

    scrollItem.scrollIntoView(scrollBlock);
  }
};
```
- 마지막 옵션 카드를 클릭하면 옵션카드를 감싸고 있는 컨테이너의 레이아웃이 변경되는 버그발생
- `scrollIntoView`의 `block`프로퍼티 값을 `center`로 고정할 경우 옵션 카드를 감싸고 있는 컨테이너가 마지막 요소의 가운데로 정렬되기 때문에 컨테이너의 위치가 변경됨
- 마지막 옵션 카드일 경우에는 `scrollIntoView`의 parameter의 `block` 프로퍼티의 값을 `end`로 변경하여 전달
- 마지막 카드의 끝 부분을 기준으로 정렬되기 때문에, 위치가 변경되지 않음.
