### PR TITLE
[BE] WebMvcConfigurer로 CORS 설정

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/global/config/WebConfig.java
+++ b/backend/src/main/java/com/example/backend/domain/global/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.example.backend.domain.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/v1/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET","POST")
+                .allowedHeaders("*")
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## 🔖 관련 이슈
- #110 

## 📝 구현 사항
- WebMvcConfigurer 구현해서 CORS 설정
- "/api/v1" 으로 시작하는 요청만 허용하게 함
- localhost에선 확인 됨
<img width="737" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/75351686/d25faec0-6bb6-4315-a555-dae0647aaa7d">


### 참고
- [갓성태](https://codedbyjst.tistory.com/12)

## 📌 하고싶은 말
- 모든 Origin을 허용 시켜도 되는지....( .allowedOrigins("*") )
