### PR TITLE
[iOS] CarInfoRepository 구현 및 관련 Response DTO 정의

### DIFF
--- a/iOS_H3/DTO/CarInfo/AdditionalOptionResponse.swift
+++ b/iOS_H3/DTO/CarInfo/AdditionalOptionResponse.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+
+struct AdditionalOptionResponse: Codable {
+    let data: [AdditionalOption]
+    let message: String?
+    let code: Int?
+
+    struct AdditionalOption: Codable {
+        let id: Int?
+        let name: String?
+        let imageSrc: String?
+        let price: Int?
+        let partsSrc: String?
+    }
+}

--- a/iOS_H3/DTO/CarInfo/AdditionalOptionResponse.swift
+++ b/iOS_H3/DTO/CarInfo/AdditionalOptionResponse.swift
@@ -1,0 +1,8 @@
+//
+//  AdditionalOptionResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/BodyTypeResponse.swift
+++ b/iOS_H3/DTO/CarInfo/BodyTypeResponse.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+
+struct BodyTypeResponse: Codable {
+    let data: [BodyType]
+    let message: String?
+    let code: Int?
+
+    struct BodyType: Codable {
+        let id: Int?
+        let label: String?
+        let price: Int?
+        let iconSrc: String?
+        let imageSrc: String?
+    }
+}

--- a/iOS_H3/DTO/CarInfo/BodyTypeResponse.swift
+++ b/iOS_H3/DTO/CarInfo/BodyTypeResponse.swift
@@ -1,0 +1,8 @@
+//
+//  BodyTypeResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+import Combine
+
+final class CarInfoRepository: CarInfoRepositoryProtocol {
+    private let networkService: NetworkServiceProtocol
+
+    init(networkService: NetworkServiceProtocol) {
+        self.networkService = networkService
+    }
+
+    func fetchPowertrain(model: String, type: String) -> AnyPublisher<Result<PowertrainResponse, Error>, Never> {
+        return networkService.request(CarInfoEndpoint.powertrain(model: model, type: type))
+    }
+}

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -42,4 +42,8 @@ final class CarInfoRepository: CarInfoRepositoryProtocol {
     func fetchAdditionalOption(category: String) -> AnyPublisher<Result<AdditionalOptionResponse, Error>, Never> {
         return networkService.request(CarInfoEndpoint.additionalOption(category: category))
     }
+
+    func fetchSingleExteriorColor(optionId: Int) -> AnyPublisher<Result<SingleExteriorColorResponse, Error>, Never> {
+        return networkService.request(CarInfoEndpoint.singleExteriorColor(optionId: optionId))
+    }
 }

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -26,4 +26,8 @@ final class CarInfoRepository: CarInfoRepositoryProtocol {
     func fetchBodyType() -> AnyPublisher<Result<BodyTypeResponse, Error>, Never> {
         return networkService.request(CarInfoEndpoint.bodyType)
     }
+
+    func fetchExteriorColor() -> AnyPublisher<Result<ExteriorColorResponse, Error>, Never> {
+        return networkService.request(CarInfoEndpoint.exteriorColor)
+    }
 }

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -30,4 +30,8 @@ final class CarInfoRepository: CarInfoRepositoryProtocol {
     func fetchExteriorColor() -> AnyPublisher<Result<ExteriorColorResponse, Error>, Never> {
         return networkService.request(CarInfoEndpoint.exteriorColor)
     }
+
+    func fetchInteriorColor() -> AnyPublisher<Result<InteriorColorResponse, Error>, Never> {
+        return networkService.request(CarInfoEndpoint.interiorColor)
+    }
 }

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -22,4 +22,8 @@ final class CarInfoRepository: CarInfoRepositoryProtocol {
     func fetchDrivingSystem() -> AnyPublisher<Result<DrivingSystemResponse, Error>, Never> {
            return networkService.request(CarInfoEndpoint.drivingSystem)
        }
+
+    func fetchBodyType() -> AnyPublisher<Result<BodyTypeResponse, Error>, Never> {
+        return networkService.request(CarInfoEndpoint.bodyType)
+    }
 }

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -38,4 +38,8 @@ final class CarInfoRepository: CarInfoRepositoryProtocol {
     func fetchWheel() -> AnyPublisher<Result<WheelResponse, Error>, Never> {
         return networkService.request(CarInfoEndpoint.wheel)
     }
+
+    func fetchAdditionalOption(category: String) -> AnyPublisher<Result<AdditionalOptionResponse, Error>, Never> {
+        return networkService.request(CarInfoEndpoint.additionalOption(category: category))
+    }
 }

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -18,4 +18,8 @@ final class CarInfoRepository: CarInfoRepositoryProtocol {
     func fetchPowertrain(model: String, type: String) -> AnyPublisher<Result<PowertrainResponse, Error>, Never> {
         return networkService.request(CarInfoEndpoint.powertrain(model: model, type: type))
     }
+
+    func fetchDrivingSystem() -> AnyPublisher<Result<DrivingSystemResponse, Error>, Never> {
+           return networkService.request(CarInfoEndpoint.drivingSystem)
+       }
 }

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -34,4 +34,8 @@ final class CarInfoRepository: CarInfoRepositoryProtocol {
     func fetchInteriorColor() -> AnyPublisher<Result<InteriorColorResponse, Error>, Never> {
         return networkService.request(CarInfoEndpoint.interiorColor)
     }
+
+    func fetchWheel() -> AnyPublisher<Result<WheelResponse, Error>, Never> {
+        return networkService.request(CarInfoEndpoint.wheel)
+    }
 }

--- a/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
+++ b/iOS_H3/DTO/CarInfo/CarInfoRepository.swift
@@ -1,0 +1,8 @@
+//
+//  CarInfoRepository.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/DrivingSystemResponse.swift
+++ b/iOS_H3/DTO/CarInfo/DrivingSystemResponse.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+
+struct DrivingSystemResponse: Codable {
+    let data: [DrivingSystem]
+    let message: String?
+    let code: Int?
+
+    struct DrivingSystem: Codable {
+        let id: Int?
+        let name: String?
+        let imageSrc: String?
+        let price: Int?
+    }
+}

--- a/iOS_H3/DTO/CarInfo/DrivingSystemResponse.swift
+++ b/iOS_H3/DTO/CarInfo/DrivingSystemResponse.swift
@@ -1,0 +1,8 @@
+//
+//  DrivingSystemResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/ExteriorColorResponse.swift
+++ b/iOS_H3/DTO/CarInfo/ExteriorColorResponse.swift
@@ -1,0 +1,8 @@
+//
+//  ExteriorColorResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/ExteriorColorResponse.swift
+++ b/iOS_H3/DTO/CarInfo/ExteriorColorResponse.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+struct ExteriorColorResponse: Codable {
+    let data: [ExteriorColor]
+    let message: String?
+    let code: Int?
+
+    struct ExteriorColor: Codable {
+        let id: Int?
+        let label: String?
+        let price: Int?
+        let colorCode: String?
+        let imageSrc: String?
+        let iconSrc: String?
+    }
+}

--- a/iOS_H3/DTO/CarInfo/InteriorColorResponse.swift
+++ b/iOS_H3/DTO/CarInfo/InteriorColorResponse.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+struct InteriorColorResponse: Codable {
+    let data: [InteriorColor]
+    let message: String?
+    let code: Int?
+
+    struct InteriorColor: Codable {
+        let id: Int?
+        let label: String?
+        let price: Int?
+        let iconSrc: String?
+        let imageSrc: String?
+    }
+}

--- a/iOS_H3/DTO/CarInfo/InteriorColorResponse.swift
+++ b/iOS_H3/DTO/CarInfo/InteriorColorResponse.swift
@@ -1,0 +1,8 @@
+//
+//  InteriorColorResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/PowertrainResponse.swift
+++ b/iOS_H3/DTO/CarInfo/PowertrainResponse.swift
@@ -1,0 +1,8 @@
+//
+//  PowertrainResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/PowertrainResponse.swift
+++ b/iOS_H3/DTO/CarInfo/PowertrainResponse.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+
+struct PowertrainResponse: Decodable {
+    let data: [Powertrain]
+    let message: String?
+    let code: Int?
+
+    struct Powertrain: Decodable {
+        let id: Int?
+        let name: String?
+        let price: Int?
+        let imageSrc: String?
+    }
+}

--- a/iOS_H3/DTO/CarInfo/SingleExteriorColorResponse.swift
+++ b/iOS_H3/DTO/CarInfo/SingleExteriorColorResponse.swift
@@ -1,0 +1,8 @@
+//
+//  SingleExteriorColorResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/SingleExteriorColorResponse.swift
+++ b/iOS_H3/DTO/CarInfo/SingleExteriorColorResponse.swift
@@ -6,3 +6,18 @@
 //
 
 import Foundation
+
+struct SingleExteriorColorResponse: Codable {
+    let data: [SingleExteriorColor]
+    let message: String?
+    let code: Int?
+
+    struct SingleExteriorColor: Codable {
+        let id: Int?
+        let name: String?
+        let imageSrc: String?
+        let price: Int?
+        let colorCode: String?
+        let iconSrc: String?
+    }
+}

--- a/iOS_H3/DTO/CarInfo/WheelResponse.swift
+++ b/iOS_H3/DTO/CarInfo/WheelResponse.swift
@@ -1,0 +1,8 @@
+//
+//  WheelResponse.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/DTO/CarInfo/WheelResponse.swift
+++ b/iOS_H3/DTO/CarInfo/WheelResponse.swift
@@ -6,3 +6,18 @@
 //
 
 import Foundation
+
+struct WheelResponse: Codable {
+    let data: [Wheel]
+    let message: String?
+    let code: Int?
+
+    struct Wheel: Codable {
+        let id: Int?
+        let label: String?
+        let price: Int?
+        let imageSrc: String?
+        let parts: String?
+        let partsSrc: String?
+    }
+}

--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -109,6 +109,19 @@
 		5F5E21132A78DD21003C1185 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 5F5E21122A78DD21003C1185 /* .swiftlint.yml */; };
 		5F5F724D2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5F724C2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift */; };
 		5F5F72512A7E13600084AFD4 /* OptionCardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5F72502A7E13600084AFD4 /* OptionCardButton.swift */; };
+		5F60E4A82A8B401500531462 /* CarInfoRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4A72A8B401500531462 /* CarInfoRepositoryProtocol.swift */; };
+		5F60E4AB2A8B405900531462 /* PowertrainResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4AA2A8B405900531462 /* PowertrainResponse.swift */; };
+		5F60E4AD2A8B40CF00531462 /* DrivingSystemResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4AC2A8B40CF00531462 /* DrivingSystemResponse.swift */; };
+		5F60E4AF2A8B40F400531462 /* BodyTypeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4AE2A8B40F400531462 /* BodyTypeResponse.swift */; };
+		5F60E4B12A8B410800531462 /* ExteriorColorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4B02A8B410800531462 /* ExteriorColorResponse.swift */; };
+		5F60E4B32A8B411900531462 /* InteriorColorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4B22A8B411900531462 /* InteriorColorResponse.swift */; };
+		5F60E4B52A8B412700531462 /* WheelResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4B42A8B412700531462 /* WheelResponse.swift */; };
+		5F60E4B72A8B419D00531462 /* AdditionalOptionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4B62A8B419D00531462 /* AdditionalOptionResponse.swift */; };
+		5F60E4B92A8B41AF00531462 /* SingleExteriorColorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4B82A8B41AF00531462 /* SingleExteriorColorResponse.swift */; };
+		5F60E4BB2A8B43FD00531462 /* CarInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4BA2A8B43FD00531462 /* CarInfoRepository.swift */; };
+		5F60E4BD2A8B469C00531462 /* CarInfoEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4BC2A8B469C00531462 /* CarInfoEndpoint.swift */; };
+		5F60E4BF2A8B4DE700531462 /* ConstantKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4BE2A8B4DE700531462 /* ConstantKey.swift */; };
+		5F60E4C02A8B4DE700531462 /* ConstantKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60E4BE2A8B4DE700531462 /* ConstantKey.swift */; };
 		5F6203692A7BC59500D09531 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6203682A7BC59500D09531 /* AppDelegate.swift */; };
 		5F62036B2A7BC59500D09531 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F62036A2A7BC59500D09531 /* SceneDelegate.swift */; };
 		5F62036D2A7BC59500D09531 /* ComponentMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F62036C2A7BC59500D09531 /* ComponentMainViewController.swift */; };
@@ -236,6 +249,18 @@
 		5F5E21122A78DD21003C1185 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		5F5F724C2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyCarSetTitleBarViewController.swift; sourceTree = "<group>"; };
 		5F5F72502A7E13600084AFD4 /* OptionCardButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionCardButton.swift; sourceTree = "<group>"; };
+		5F60E4A72A8B401500531462 /* CarInfoRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CarInfoRepositoryProtocol.swift; path = iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4AA2A8B405900531462 /* PowertrainResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PowertrainResponse.swift; path = DTO/CarInfo/PowertrainResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4AC2A8B40CF00531462 /* DrivingSystemResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DrivingSystemResponse.swift; path = DTO/CarInfo/DrivingSystemResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4AE2A8B40F400531462 /* BodyTypeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BodyTypeResponse.swift; path = DTO/CarInfo/BodyTypeResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4B02A8B410800531462 /* ExteriorColorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExteriorColorResponse.swift; path = DTO/CarInfo/ExteriorColorResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4B22A8B411900531462 /* InteriorColorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InteriorColorResponse.swift; path = DTO/CarInfo/InteriorColorResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4B42A8B412700531462 /* WheelResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WheelResponse.swift; path = DTO/CarInfo/WheelResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4B62A8B419D00531462 /* AdditionalOptionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AdditionalOptionResponse.swift; path = DTO/CarInfo/AdditionalOptionResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4B82A8B41AF00531462 /* SingleExteriorColorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SingleExteriorColorResponse.swift; path = DTO/CarInfo/SingleExteriorColorResponse.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4BA2A8B43FD00531462 /* CarInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CarInfoRepository.swift; path = DTO/CarInfo/CarInfoRepository.swift; sourceTree = SOURCE_ROOT; };
+		5F60E4BC2A8B469C00531462 /* CarInfoEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarInfoEndpoint.swift; sourceTree = "<group>"; };
+		5F60E4BE2A8B4DE700531462 /* ConstantKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantKey.swift; sourceTree = "<group>"; };
 		5F6203662A7BC59500D09531 /* iOS_H3_UI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOS_H3_UI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F6203682A7BC59500D09531 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5F62036A2A7BC59500D09531 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -406,6 +431,7 @@
 				471917C92A7FA02000B67D54 /* CarMakingStep.swift */,
 				5F4D33AE2A87519600942517 /* ImageCacheManager.swift */,
 				5F371BB02A88B99800E6CFCD /* OptionCategoryType.swift */,
+				5F60E4BE2A8B4DE700531462 /* ConstantKey.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -423,6 +449,7 @@
 			isa = PBXGroup;
 			children = (
 				478B267F2A78FD2400598902 /* Protocol */,
+				5F60E4BA2A8B43FD00531462 /* CarInfoRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -437,6 +464,7 @@
 		478B267E2A78FD0E00598902 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				5F60E4A92A8B403600531462 /* CarInfo */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -444,6 +472,7 @@
 		478B267F2A78FD2400598902 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				5F60E4A72A8B401500531462 /* CarInfoRepositoryProtocol.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -519,6 +548,7 @@
 				479023AC2A8AA18600DECB70 /* NetworkService.swift */,
 				479023AD2A8AA18600DECB70 /* NetworkError.swift */,
 				479023AE2A8AA18600DECB70 /* EndPoint.swift */,
+				5F60E4BC2A8B469C00531462 /* CarInfoEndpoint.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -628,6 +658,21 @@
 				5F2593E12A7FCA16001B2D84 /* OptionCardButtonViewController.swift */,
 			);
 			path = OptionCardButton;
+			sourceTree = "<group>";
+		};
+		5F60E4A92A8B403600531462 /* CarInfo */ = {
+			isa = PBXGroup;
+			children = (
+				5F60E4AA2A8B405900531462 /* PowertrainResponse.swift */,
+				5F60E4AC2A8B40CF00531462 /* DrivingSystemResponse.swift */,
+				5F60E4AE2A8B40F400531462 /* BodyTypeResponse.swift */,
+				5F60E4B02A8B410800531462 /* ExteriorColorResponse.swift */,
+				5F60E4B22A8B411900531462 /* InteriorColorResponse.swift */,
+				5F60E4B42A8B412700531462 /* WheelResponse.swift */,
+				5F60E4B62A8B419D00531462 /* AdditionalOptionResponse.swift */,
+				5F60E4B82A8B41AF00531462 /* SingleExteriorColorResponse.swift */,
+			);
+			path = CarInfo;
 			sourceTree = "<group>";
 		};
 		5F6203672A7BC59500D09531 /* iOS_H3_UI */ = {
@@ -982,6 +1027,7 @@
 				479023B02A8AA18600DECB70 /* NetworkService.swift in Sources */,
 				4790239F2A8A3E0D00DECB70 /* SceneDelegate.swift in Sources */,
 				479023B22A8AA18600DECB70 /* NetworkError.swift in Sources */,
+				5F60E4C02A8B4DE700531462 /* ConstantKey.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -998,16 +1044,25 @@
 				47CB8CB92A79F1DE004B24AD /* Fonts.swift in Sources */,
 				5F00FBF92A777BDE0055A4FA /* ViewController.swift in Sources */,
 				5F5F72512A7E13600084AFD4 /* OptionCardButton.swift in Sources */,
+				5F60E4B92A8B41AF00531462 /* SingleExteriorColorResponse.swift in Sources */,
 				5F2593DE2A7FB3FD001B2D84 /* TagListView.swift in Sources */,
 				4700964B2A87964B003711F2 /* EstimateSummaryView.swift in Sources */,
+				5F60E4BB2A8B43FD00531462 /* CarInfoRepository.swift in Sources */,
 				479023B62A8B231200DECB70 /* URL+.swift in Sources */,
 				477620C52A7B80B900D60B59 /* UILabel+.swift in Sources */,
+				5F60E4AB2A8B405900531462 /* PowertrainResponse.swift in Sources */,
+				5F60E4B12A8B410800531462 /* ExteriorColorResponse.swift in Sources */,
 				5F6A82F42A887B0B0025D5A4 /* OptionCategoryTabBar.swift in Sources */,
+				5F60E4AD2A8B40CF00531462 /* DrivingSystemResponse.swift in Sources */,
 				5F8EBC4A2A81203C00C885CE /* OhMyCarSetTitleBar.swift in Sources */,
+				5F60E4B72A8B419D00531462 /* AdditionalOptionResponse.swift in Sources */,
 				471917C22A7E422900B67D54 /* OhMyCarSetButtonViewController.swift in Sources */,
 				471917C62A7EA8C800B67D54 /* CarMakingProgressBarButton.swift in Sources */,
+				5F60E4B32A8B411900531462 /* InteriorColorResponse.swift in Sources */,
+				5F60E4A82A8B401500531462 /* CarInfoRepositoryProtocol.swift in Sources */,
 				477620F52A7BECC400D60B59 /* OhMyCarSetButton.swift in Sources */,
 				4719180B2A83651500B67D54 /* MultiOptionCardButtonViewController.swift in Sources */,
+				5F60E4AF2A8B40F400531462 /* BodyTypeResponse.swift in Sources */,
 				471917FF2A8339B100B67D54 /* MultiOptionCardButtonView.swift in Sources */,
 				5F3B50B92A79EDA900158E96 /* Colors.swift in Sources */,
 				471917C42A7EA5A700B67D54 /* CarMakingProgressBar.swift in Sources */,
@@ -1015,6 +1070,7 @@
 				471917CC2A7FB11600B67D54 /* CarMakingProgressBarSpacingView.swift in Sources */,
 				471917C82A7F8CD500B67D54 /* CarMakingProgressBarViewController.swift in Sources */,
 				471918052A834D8600B67D54 /* OptionCardCell.swift in Sources */,
+				5F60E4BF2A8B4DE700531462 /* ConstantKey.swift in Sources */,
 				5F00FBF52A777BDE0055A4FA /* AppDelegate.swift in Sources */,
 				5F4D33AF2A87519600942517 /* ImageCacheManager.swift in Sources */,
 				479023B32A8AA18600DECB70 /* EndPoint.swift in Sources */,
@@ -1027,9 +1083,11 @@
 				479023B12A8AA18600DECB70 /* NetworkError.swift in Sources */,
 				5F2593E22A7FCA16001B2D84 /* OptionCardButtonViewController.swift in Sources */,
 				5F2593E02A7FBCFE001B2D84 /* OptionMotionView.swift in Sources */,
+				5F60E4B52A8B412700531462 /* WheelResponse.swift in Sources */,
 				479023AF2A8AA18600DECB70 /* NetworkService.swift in Sources */,
 				471917D62A811D3F00B67D54 /* OptionCardInfo.swift in Sources */,
 				5F6603EF2A8380C8000E393D /* CarMakingMultipleOptionCell.swift in Sources */,
+				5F60E4BD2A8B469C00531462 /* CarInfoEndpoint.swift in Sources */,
 				5F4D33B52A8758FF00942517 /* PageSection.swift in Sources */,
 				5F4DB0EF2A89A6C200E905A7 /* UIView+.swift in Sources */,
 				471917D22A8118E200B67D54 /* TwoOptionCardButtonViewController.swift in Sources */,

--- a/iOS_H3/iOS_H3.xcodeproj/xcuserdata/kojeongmin.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/iOS_H3/iOS_H3.xcodeproj/xcuserdata/kojeongmin.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -4,15 +4,20 @@
 <dict>
 	<key>SchemeUserState</key>
 	<dict>
-		<key>iOS_H3.xcscheme_^#shared#^_</key>
+		<key>NetworkLayerTest.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
-		<key>iOS_H3_UI.xcscheme_^#shared#^_</key>
+		<key>iOS_H3.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
 			<integer>1</integer>
+		</dict>
+		<key>iOS_H3_UI.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>

--- a/iOS_H3/iOS_H3/Source/ConstantKey.swift
+++ b/iOS_H3/iOS_H3/Source/ConstantKey.swift
@@ -1,0 +1,8 @@
+//
+//  ConstantKey.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/iOS_H3/Source/ConstantKey.swift
+++ b/iOS_H3/iOS_H3/Source/ConstantKey.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+class ConstantKey {
+    private init() {}
+    static let baseURL = "http://43.202.37.97:9999/api/"
+
+}

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -16,4 +16,6 @@ protocol CarInfoRepositoryProtocol {
     func fetchBodyType() -> AnyPublisher<Result<BodyTypeResponse, Error>, Never>
 
     func fetchExteriorColor() -> AnyPublisher<Result<ExteriorColorResponse, Error>, Never>
+
+    func fetchInteriorColor() -> AnyPublisher<Result<InteriorColorResponse, Error>, Never>
 }

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -22,4 +22,6 @@ protocol CarInfoRepositoryProtocol {
     func fetchWheel() -> AnyPublisher<Result<WheelResponse, Error>, Never>
 
     func fetchAdditionalOption(category: String) -> AnyPublisher<Result<AdditionalOptionResponse, Error>, Never>
+
+    func fetchSingleExteriorColor(optionId: Int) -> AnyPublisher<Result<SingleExteriorColorResponse, Error>, Never>
 }

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+import Combine
+
+protocol CarInfoRepositoryProtocol {
+    func fetchPowertrain(model: String, type: String) -> AnyPublisher<Result<PowertrainResponse, Error>, Never>
+   
+}

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -1,0 +1,8 @@
+//
+//  CarInfoRepositoryProtocol.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -20,4 +20,6 @@ protocol CarInfoRepositoryProtocol {
     func fetchInteriorColor() -> AnyPublisher<Result<InteriorColorResponse, Error>, Never>
 
     func fetchWheel() -> AnyPublisher<Result<WheelResponse, Error>, Never>
+
+    func fetchAdditionalOption(category: String) -> AnyPublisher<Result<AdditionalOptionResponse, Error>, Never>
 }

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -12,4 +12,6 @@ protocol CarInfoRepositoryProtocol {
     func fetchPowertrain(model: String, type: String) -> AnyPublisher<Result<PowertrainResponse, Error>, Never>
 
     func fetchDrivingSystem() -> AnyPublisher<Result<DrivingSystemResponse, Error>, Never>
+
+    func fetchBodyType() -> AnyPublisher<Result<BodyTypeResponse, Error>, Never>
 }

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -10,5 +10,6 @@ import Combine
 
 protocol CarInfoRepositoryProtocol {
     func fetchPowertrain(model: String, type: String) -> AnyPublisher<Result<PowertrainResponse, Error>, Never>
-   
+
+    func fetchDrivingSystem() -> AnyPublisher<Result<DrivingSystemResponse, Error>, Never>
 }

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -18,4 +18,6 @@ protocol CarInfoRepositoryProtocol {
     func fetchExteriorColor() -> AnyPublisher<Result<ExteriorColorResponse, Error>, Never>
 
     func fetchInteriorColor() -> AnyPublisher<Result<InteriorColorResponse, Error>, Never>
+
+    func fetchWheel() -> AnyPublisher<Result<WheelResponse, Error>, Never>
 }

--- a/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/CarInfoRepositoryProtocol.swift
@@ -14,4 +14,6 @@ protocol CarInfoRepositoryProtocol {
     func fetchDrivingSystem() -> AnyPublisher<Result<DrivingSystemResponse, Error>, Never>
 
     func fetchBodyType() -> AnyPublisher<Result<BodyTypeResponse, Error>, Never>
+
+    func fetchExteriorColor() -> AnyPublisher<Result<ExteriorColorResponse, Error>, Never>
 }

--- a/iOS_H3/iOS_H3/Source/Network/CarInfoEndpoint.swift
+++ b/iOS_H3/iOS_H3/Source/Network/CarInfoEndpoint.swift
@@ -1,0 +1,8 @@
+//
+//  CarInfoEndpoint.swift
+//  iOS_H3
+//
+//  Created by KoJeongMin  on 2023/08/15.
+//
+
+import Foundation

--- a/iOS_H3/iOS_H3/Source/Network/CarInfoEndpoint.swift
+++ b/iOS_H3/iOS_H3/Source/Network/CarInfoEndpoint.swift
@@ -6,3 +6,50 @@
 //
 
 import Foundation
+
+enum CarInfoEndpoint: Endpoint {
+    case powertrain(model: String, type: String)
+    case drivingSystem
+    case bodyType
+    case exteriorColor
+    case interiorColor
+    case wheel
+    case additionalOption(category: String)
+    case singleExteriorColor(optionId: Int)
+
+    var baseURL: String { ConstantKey.baseURL }
+    var httpMethod: HTTPMethod { .GET }
+    var headers: [String: String] { [:] }
+
+    var path: String {
+        switch self {
+        case .powertrain:
+            return "/powertrain"
+        case .drivingSystem:
+            return "/driving-system"
+        case .bodyType:
+            return "/bodytype"
+        case .exteriorColor:
+            return "/exterior-color"
+        case .interiorColor:
+            return "/interior-color"
+        case .wheel:
+            return "/wheel"
+        case .additionalOption:
+            return "/additional-option"
+        case .singleExteriorColor(let optionId):
+            return "/exterior-color/\(optionId)"
+        }
+    }
+
+    var parameters: HTTPParameter? {
+        switch self {
+        case .powertrain(let model, let type):
+            return .query(["model": model, "type": type])
+        case .additionalOption(let category):
+            return .query(["category": category])
+        default:
+            return nil
+        }
+    }
+}


### PR DESCRIPTION


## 🔖 관련 이슈
- #127 

## 📝 구현 사항
- ConstantKey 구조체를 통한 베이스 URL 선언
- CarInfoEndpoint enum을 통한 엔드포인트 관리
- CarInfoRepository와 CarInfoRepositoryProtocol 클래스 및 프로토콜 정의
- 차량 정보와 관련된 다양한 응답 모델(PowertrainResponse, DrivingSystemResponse, BodyTypeResponse, 등) 정의
- 차량의 외장/내장 색상, 바퀴, 추가 옵션 등의 정보를 가져오는 메서드 구현

<img width="600" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68258365/85f1618a-4630-4635-bcea-88f9cef61416">

## 고민한 부분
현재까지 백엔드 개발자분들이 명세서에 나눠놓은 도메인대로 레포지토리를 분리할 생각입니다. 
예상되는 도메인은 다음과 같습니다:
- 메인화면
- 백카사전
- 자동차 정보(파워트레인 정보 등등)
- 피드백(따봉)/추가정보(자세히보기 눌렀을 때) 관련해서 /detail/powertrain
- 추천(구매자 몇퍼 선택율, 태그 별 선택율) /recommend/powertrain
- 자동차 가이드모드 추천 완성(추천 결과 옵션들)
- 
<img width="259" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68258365/d7c4ff1f-df28-4a83-bcbd-d2a3b0a8d44e">

## 📌 하고싶은 말
- 아직 에러 처리 관련한 부분은 statusCode를 보고 작업해야할 것 같아서 하지 않았습니다.
