### PR TITLE
[iOS] 내차만들기 ViewController 구현

### DIFF
--- a/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
+++ b/iOS_H3/iOS_H3.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		479023B72A8B231200DECB70 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479023B52A8B231200DECB70 /* URL+.swift */; };
 		479023B92A8B231D00DECB70 /* URLRequest+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479023B82A8B231D00DECB70 /* URLRequest+.swift */; };
 		479023BA2A8B231D00DECB70 /* URLRequest+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479023B82A8B231D00DECB70 /* URLRequest+.swift */; };
+		479023BC2A8B4BE600DECB70 /* CarMakingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479023BB2A8B4BE600DECB70 /* CarMakingViewController.swift */; };
 		479023BE2A8B4D8B00DECB70 /* CarMakingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479023BD2A8B4D8B00DECB70 /* CarMakingMode.swift */; };
 		479023BF2A8B4E0500DECB70 /* CarMakingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479023BD2A8B4D8B00DECB70 /* CarMakingMode.swift */; };
 		479023C02A8B4E0600DECB70 /* CarMakingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479023BD2A8B4D8B00DECB70 /* CarMakingMode.swift */; };
@@ -207,6 +208,7 @@
 		479023AE2A8AA18600DECB70 /* EndPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		479023B52A8B231200DECB70 /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
 		479023B82A8B231D00DECB70 /* URLRequest+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+.swift"; sourceTree = "<group>"; };
+		479023BB2A8B4BE600DECB70 /* CarMakingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarMakingViewController.swift; sourceTree = "<group>"; };
 		479023BD2A8B4D8B00DECB70 /* CarMakingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarMakingMode.swift; sourceTree = "<group>"; };
 		47CB8CB02A79ECD4004B24AD /* HyundaiSansHeadKRMedium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRMedium.ttf; sourceTree = "<group>"; };
 		47CB8CB22A79ECE0004B24AD /* HyundaiSansHeadKRRegular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = HyundaiSansHeadKRRegular.ttf; sourceTree = "<group>"; };
@@ -373,7 +375,7 @@
 		478B26772A78FC5C00598902 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				478B26832A78FD4000598902 /* SelfMode */,
+				478B26832A78FD4000598902 /* CarMaking */,
 				5F00FBF82A777BDE0055A4FA /* ViewController.swift */,
 			);
 			path = Presentation;
@@ -477,19 +479,20 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
-		478B26832A78FD4000598902 /* SelfMode */ = {
+		478B26832A78FD4000598902 /* CarMaking */ = {
 			isa = PBXGroup;
 			children = (
 				478B26862A78FD8D00598902 /* View */,
 				478B26852A78FD8700598902 /* ViewModel */,
 				478B26842A78FD8200598902 /* ViewController */,
 			);
-			path = SelfMode;
+			path = CarMaking;
 			sourceTree = "<group>";
 		};
 		478B26842A78FD8200598902 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				479023BB2A8B4BE600DECB70 /* CarMakingViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -996,6 +999,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F4D33B22A8751E500942517 /* UIImageView+.swift in Sources */,
+				479023BC2A8B4BE600DECB70 /* CarMakingViewController.swift in Sources */,
 				5F99F0632A85171600C38555 /* CarMakingContentView.swift in Sources */,
 				5F5F724D2A7E03460084AFD4 /* OhMyCarSetTitleBarViewController.swift in Sources */,
 				471917DE2A81F9A200B67D54 /* OptionCardButtonListViewable.swift in Sources */,

--- a/iOS_H3/iOS_H3/Source/App/SceneDelegate.swift
+++ b/iOS_H3/iOS_H3/Source/App/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = ViewController()
+        window?.rootViewController = CarMakingViewController(mode: .selfMode)
         window?.makeKeyAndVisible()
     }
 

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -1,0 +1,142 @@
+//
+//  CarMakingViewController.swift
+//  iOS_H3
+//
+//  Created by  sangyeon on 2023/08/15.
+//
+
+import UIKit
+
+final class CarMakingViewController: UIViewController {
+
+    enum Constants {
+        static let titleBarHeight = 50.0
+    }
+
+    // MARK: - UI properties
+
+    private var titleBar: OhMyCarSetTitleBar!
+
+    private var carMakingContentView: CarMakingContentView<PageSection>!
+
+    // MARK: - Properties
+
+    private let mode: CarMakingMode
+
+    // MARK: - Lifecycles
+
+    init(mode: CarMakingMode) {
+        self.mode = mode
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        self.mode = .selfMode
+        super.init(coder: coder)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupProperties()
+        setupViews()
+    }
+
+    // MARK: - Helpers
+}
+
+// MARK: - OhMyCarSetTitleBar Delegate
+
+extension CarMakingViewController: OhMyCarSetTitleBarDelegate {
+
+    func titleBarBackButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
+        print("[CarMakingViewController]", #function, "백버튼 클릭 액션 구현 필요")
+    }
+
+    func titleBarTitleButtonTapped(_ titleBar: OhMyCarSetTitleBar) {
+        print("[CarMakingViewController]", #function, "title 버튼 클릭 액션 구현 필요")
+    }
+
+    func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
+        print("[CarMakingViewController]", #function, "백카사전 버튼 클릭 액션 구현 필요")
+    }
+
+    func titleBarChangeModelButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
+        print("[CarMakingViewController]", #function, "모드변경 버튼 클릭 액션 구현 필요")
+    }
+}
+
+// MARK: - CarMakingContentView DataSource
+
+extension CarMakingViewController: CarMakingContentViewDataSource {
+
+    func carMakingContentView(urlForItemAtIndex indexPath: IndexPath) -> String? {
+        return nil
+    }
+
+    func carMakingContentView(optionsForItemAtIndex indexPath: IndexPath) -> [OptionCardInfo]? {
+        return nil
+    }
+}
+
+// MARK: - Setup Properties
+
+extension CarMakingViewController {
+
+    private func setupProperties() {
+        initTitleBar()
+        initContentView()
+    }
+
+    private func initTitleBar() {
+        let titleBarType: OhMyCarSetTitleBar.NavigationBarType = (mode == .selfMode) ? .selfMode : .guideMode
+        titleBar = OhMyCarSetTitleBar(type: titleBarType)
+        titleBar.delegate = self
+        titleBar.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private func initContentView() {
+        carMakingContentView = CarMakingContentView(frame: .zero, mode: mode)
+        carMakingContentView.dataSource = self
+        carMakingContentView.translatesAutoresizingMaskIntoConstraints = false
+    }
+}
+
+// MARK: - SetupViews
+
+extension CarMakingViewController {
+
+    private func setupViews() {
+        view.backgroundColor = .white
+        addSubviews()
+        setupConstraints()
+    }
+
+    private func addSubviews() {
+        view.addSubview(titleBar)
+        view.addSubview(carMakingContentView)
+    }
+
+    private func setupConstraints() {
+        setupTitleBarConstraints()
+        setupContentViewConstraints()
+    }
+
+    private func setupTitleBarConstraints() {
+        NSLayoutConstraint.activate([
+            titleBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            titleBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            titleBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            titleBar.heightAnchor.constraint(equalToConstant: Constants.titleBarHeight)
+        ])
+    }
+
+    private func setupContentViewConstraints() {
+        NSLayoutConstraint.activate([
+            carMakingContentView.topAnchor.constraint(equalTo: titleBar.bottomAnchor),
+            carMakingContentView.leadingAnchor.constraint(equalTo: titleBar.leadingAnchor),
+            carMakingContentView.trailingAnchor.constraint(equalTo: titleBar.trailingAnchor),
+            carMakingContentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+}

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 protocol CarMakingContentViewDataSource: AnyObject {
-    func contentView(urlForItemAtIndex indexPath: IndexPath) -> String?
-    func contentView(optionsForItemAtIndex indexPath: IndexPath) -> [OptionCardInfo]?
+    func carMakingContentView(urlForItemAtIndex indexPath: IndexPath) -> String?
+    func carMakingContentView(optionsForItemAtIndex indexPath: IndexPath) -> [OptionCardInfo]?
 }
 
 // 섹션을 정의하기 위한 기본 인터페이스
@@ -28,7 +28,7 @@ class CarMakingContentView<Section: CarMakingSectionType>: UIView, UICollectionV
 
     var collectionViewDataSource: UICollectionViewDiffableDataSource<Section, CarMakingStep>!
 
-    weak var dataSource: (CarMakingContentViewDataSource)? {
+    weak var dataSource: CarMakingContentViewDataSource? {
         didSet {
             setupSnapshot()
         }
@@ -132,7 +132,8 @@ extension CarMakingContentView {
 
      func setupCollectionViewDataSource() {
          collectionViewDataSource = UICollectionViewDiffableDataSource<Section, CarMakingStep>(
-              collectionView: collectionView) { [weak self] (collectionView, indexPath, step)
+            collectionView: collectionView
+         ) { [weak self] (collectionView, indexPath, step)
                   -> UICollectionViewCell? in
             let section = PageSection.allCases[indexPath.section]
             guard let self,
@@ -142,8 +143,8 @@ extension CarMakingContentView {
                 return CarMakingCollectionViewCell()
             }
 
-            let urlString = self.dataSource?.contentView(urlForItemAtIndex: indexPath)
-            let options = self.dataSource?.contentView(optionsForItemAtIndex: indexPath) ?? []
+            let urlString = self.dataSource?.carMakingContentView(urlForItemAtIndex: indexPath)
+            let options = self.dataSource?.carMakingContentView(optionsForItemAtIndex: indexPath) ?? []
             cell.configure(mode: self.carMakingMode,
                            bannerImage: urlString,
                            makingStepTitle: step.title,

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
@@ -8,9 +8,6 @@
 import UIKit
 
 protocol CarMakingContentViewDataSource: AnyObject {
-    func numberOfSections() -> Int
-    func contentView(numberOfItemsInSection section: Int) -> Int
-    func contentView(stepAtIndexPath indexPath: IndexPath) -> CarMakingStep
     func contentView(urlForItemAtIndex indexPath: IndexPath) -> String?
     func contentView(optionsForItemAtIndex indexPath: IndexPath) -> [OptionCardInfo]?
 }

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
@@ -65,24 +65,24 @@ final class CarMakingContentViewController: UIViewController {
     }
 }
 extension CarMakingContentViewController: OhMyCarSetTitleBarDelegate {
-    func titleButtonTapped() {
+    func titleBarTitleButtonTapped(_ titleBar: OhMyCarSetTitleBar) {
         print("titleButton Pressed")
     }
 
-    func backButtonPressed() {
+    func titleBarBackButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("backButton Pressed")
         self.dismiss(animated: true)
     }
 
-    func skipButtonPressed() {
+    func titleBarSkipButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("skipButton Pressed")
     }
 
-    func dictionaryButtonPressed() {
+    func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("dictionaryButton Pressed")
     }
 
-    func changeModelButtonPressed() {
+    func titleBarChangeModelButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("changeModelButton Pressed")
     }
 }

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
@@ -89,18 +89,6 @@ extension CarMakingContentViewController: OhMyCarSetTitleBarDelegate {
 
 extension CarMakingContentViewController: CarMakingContentViewDataSource {
 
-    func numberOfSections() -> Int {
-        return PageSection.allCases.count
-    }
-
-    func contentView(numberOfItemsInSection section: Int) -> Int {
-        return CarMakingStep.allCases.count
-    }
-
-    func contentView(stepAtIndexPath indexPath: IndexPath) -> CarMakingStep {
-        return CarMakingStep.allCases[indexPath.row]
-    }
-
     func contentView(urlForItemAtIndex indexPath: IndexPath) -> String? {
         return CarMakingContentMockData.mockURL[indexPath.section][indexPath.row]
     }

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
@@ -89,11 +89,11 @@ extension CarMakingContentViewController: OhMyCarSetTitleBarDelegate {
 
 extension CarMakingContentViewController: CarMakingContentViewDataSource {
 
-    func contentView(urlForItemAtIndex indexPath: IndexPath) -> String? {
+    func carMakingContentView(urlForItemAtIndex indexPath: IndexPath) -> String? {
         return CarMakingContentMockData.mockURL[indexPath.section][indexPath.row]
     }
 
-    func contentView(optionsForItemAtIndex indexPath: IndexPath) -> [OptionCardInfo]? {
+    func carMakingContentView(optionsForItemAtIndex indexPath: IndexPath) -> [OptionCardInfo]? {
         return CarMakingContentMockData.mockOption[indexPath.section][indexPath.row]
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -62,6 +62,7 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
     /// 카드 info에 따라 모든 옵션 카드의 view를 업데이트
     func updateAllViews(with cardInfos: [OptionCardInfo]) {
         optionCardButtons.enumerated().forEach { (index, _) in
+            if cardInfos.count <= index { return }
             updateView(index: index, with: cardInfos[index])
         }
     }

--- a/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBar.swift
+++ b/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBar.swift
@@ -8,12 +8,12 @@
 import Foundation
 import UIKit
 
-protocol OhMyCarSetTitleBarDelegate: AnyObject {
-    func backButtonPressed()
-    func skipButtonPressed()
-    func dictionaryButtonPressed()
-    func changeModelButtonPressed()
-    func titleButtonTapped()
+@objc protocol OhMyCarSetTitleBarDelegate: AnyObject {
+    @objc optional func titleBarBackButtonPressed(_ titleBar: OhMyCarSetTitleBar)
+    @objc optional func titleBarSkipButtonPressed(_ titleBar: OhMyCarSetTitleBar)
+    @objc optional func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar)
+    @objc optional func titleBarChangeModelButtonPressed(_ titleBar: OhMyCarSetTitleBar)
+    @objc optional func titleBarTitleButtonTapped(_ titleBar: OhMyCarSetTitleBar)
 }
 
 class OhMyCarSetTitleBar: UIView {
@@ -175,25 +175,25 @@ class OhMyCarSetTitleBar: UIView {
     }
 
     @objc private func backButtonTapped() {
-        delegate?.backButtonPressed()
+        delegate?.titleBarBackButtonPressed?(self)
     }
 
     @objc private func skipButtonTapped() {
-        delegate?.skipButtonPressed()
+        delegate?.titleBarSkipButtonPressed?(self)
     }
 
     @objc private func dictionaryButtonTapped(_ sender: UIButton) {
         isDictionaryButtonOn.toggle()
         let buttonImage = isDictionaryButtonOn ? "dictionary_on_img" : "dictionary_off_img"
         sender.setImage(UIImage(named: buttonImage), for: .normal)
-        delegate?.dictionaryButtonPressed()
+        delegate?.titleBarDictionaryButtonPressed?(self)
     }
 
     @objc private func changeModelButtonTapped() {
-        delegate?.changeModelButtonPressed()
+        delegate?.titleBarChangeModelButtonPressed?(self)
     }
     @objc private func titleLogoButtonTapped() {
-        delegate?.titleButtonTapped()
+        delegate?.titleBarTitleButtonTapped?(self)
     }
 
     private func setTitleLabel() {

--- a/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBar.swift
+++ b/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBar.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 @objc protocol OhMyCarSetTitleBarDelegate: AnyObject {
-    @objc optional func titleBarBackButtonPressed(_ titleBar: OhMyCarSetTitleBar)
+    func titleBarBackButtonPressed(_ titleBar: OhMyCarSetTitleBar)
     @objc optional func titleBarSkipButtonPressed(_ titleBar: OhMyCarSetTitleBar)
     @objc optional func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar)
     @objc optional func titleBarChangeModelButtonPressed(_ titleBar: OhMyCarSetTitleBar)
@@ -175,7 +175,7 @@ class OhMyCarSetTitleBar: UIView {
     }
 
     @objc private func backButtonTapped() {
-        delegate?.titleBarBackButtonPressed?(self)
+        delegate?.titleBarBackButtonPressed(self)
     }
 
     @objc private func skipButtonTapped() {

--- a/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBarViewController.swift
+++ b/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBarViewController.swift
@@ -75,23 +75,23 @@ class OhMyCarSetTitleBarViewController: UIViewController {
 }
 
 extension OhMyCarSetTitleBarViewController: OhMyCarSetTitleBarDelegate {
-    func titleButtonTapped() {
+    func titleBarTitleButtonTapped(_ titleBar: OhMyCarSetTitleBar) {
         print("titleButton Pressed")
     }
 
-    func backButtonPressed() {
+    func titleBarBackButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("backButton Pressed")
     }
 
-    func skipButtonPressed() {
+    func titleBarSkipButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("skipButton Pressed")
     }
 
-    func dictionaryButtonPressed() {
+    func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("dictionaryButton Pressed")
     }
 
-    func changeModelButtonPressed() {
+    func titleBarChangeModelButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         print("changeModelButton Pressed")
     }
 }


### PR DESCRIPTION
## 🔖 관련 이슈
- #131 

## 📝 구현 사항

### OhMyCarSetTitleBarDelegate 수정

- `@objc` 프로토콜로 수정했습니다.
- `@objc optional` 사용하여 선택적으로 delegate 메소드들을 구현할 수 있도록 수정했습니다.
  - 이유 : OhMyCarSetTitleBar에는 NavigationBarType이 4가지가 존재하는데 메인, 셀프모드, 가이드모드에서는 온보딩에서만 skipButton이 사용되지 않고 반대의 경우도 마찬가지입니다. 그래서 모든 타입에 공통적으로 존재하는 요소인 BackButton 클릭 관련 메소드를 제외한 delegate 메소드는 옵셔널로 처리해주었습니다.

- 수업시간에 배운 Delegate 메소드명 규칙에 따라 메소드명을 수정했습니다.

### CarMakingContentViewDataSource 수정

- CarMakingContentViewDataSource 메소드 중 사용되지 않는 `numberOfSections()`, `contentView(numberOfItemsInSection:)`, `contentView(stepAtIndexPath:)` 메소드를 삭제했습니다
- 마찬가지로 DataSource 메소드명 규칙에 따라 메소드명을 수정했습니다.

### CarMakingViewController 구현

- init시 `CarMakingMode` (셀프모드 혹은 가이드모드) 를 전달하여 인스턴스를 생성합니다. 
  => `CarMakingViewController(mode: .selfMode)`

## 하고싶은 말

`CarMakingContentViewDataSource` 메소드명 수정 시 규칙에 따라 첫번째 매개변수에 자기 자신의 인스턴스를 넣으려고 했는데
`Reference to generic type 'CarMakingContentView' requires arguments in <...>` 에러가 있었고
그에 따라 다음과 같이 수정했습니다. 

```swift
protocol CarMakingContentViewDataSource: AnyObject {
    associatedtype Section: CarMakingSectionType
    func carMakingContentView(_ carMakingContentView: CarMakingContentView<Section>, urlForItemAtIndex indexPath: IndexPath) -> String?
    ...
}
```

그러니까 아래 영역에서 에러가 발생했습니다.

<img width="1071" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/52f1b971-3eec-4924-b56f-d496676b2a23">

```
에러1. Cannot convert value of type 'CarMakingContentView<Section>' to expected argument type 'CarMakingContentView<any CarMakingSectionType>'
에러2. Member 'carMakingContentView' cannot be used on value of type 'any CarMakingContentViewDataSource'; consider using a generic constraint instead
```

해당 부분을 해결하지 못해서 우선 CarMakingContentViewDataSource 메소드는 첫번째 매개변수에 인스턴스 전달하는 것은 제외하고 구현했습니다! 

참고상 말씀드립니다