### PR TITLE
[FE] DetailBox에 API오류 수정

### DIFF
--- a/frontend/src/component/content/right/OptionCardList.tsx
+++ b/frontend/src/component/content/right/OptionCardList.tsx
@@ -1,18 +1,12 @@
-import React, {useEffect, useState, useContext, useRef} from 'react';
+import React, {useEffect, useState, useRef} from 'react';
 import styled, {keyframes} from 'styled-components';
 import OptionCard from './card/OptionCard';
 import {cardDataType} from '../contentInterface';
-import {OptionContext} from '@/provider/optionProvider';
-interface Data {
-  optionId: number;
-  name: string;
-  rate: number;
-  price: number;
-}
 
 interface carfListProps {
   cardData: cardDataType[];
   isSaved: boolean;
+  option: number;
   setNewIndex: (index: number) => void;
 }
 
@@ -45,15 +39,14 @@ const scrollIntoSelected = (
   }
 };
 
-function OptionCardList({cardData, setNewIndex, isSaved}: carfListProps) {
+function OptionCardList({
+  cardData,
+  setNewIndex,
+  option,
+  isSaved,
+}: carfListProps) {
   const [selectedItem, setSelectedItem] = useState<number>(0);
-  const {option} = useContext(OptionContext);
   const ulRef = useRef<HTMLUListElement>(null);
-
-  const handleItemClick = (index: number) => {
-    setNewIndex(index);
-    setSelectedItem(index);
-  };
 
   useEffect(() => {
     setSelectedItem(0);
@@ -62,6 +55,11 @@ function OptionCardList({cardData, setNewIndex, isSaved}: carfListProps) {
   useEffect(() => {
     scrollIntoSelected(ulRef, selectedItem);
   }, [selectedItem]);
+
+  const handleItemClick = (index: number) => {
+    setNewIndex(index);
+    setSelectedItem(index);
+  };
 
   const cards: React.JSX.Element[] = cardData.map((elem, index) => (
     <OptionCard
@@ -81,7 +79,9 @@ function OptionCardList({cardData, setNewIndex, isSaved}: carfListProps) {
   );
 }
 
-export default OptionCardList;
+export default React.memo(OptionCardList, (prevProps, nextProps) => {
+  return prevProps.cardData === nextProps.cardData;
+});
 
 const Wrapper = styled.div`
   &::-webkit-scrollbar {

--- a/frontend/src/component/content/right/OptionInfo.tsx
+++ b/frontend/src/component/content/right/OptionInfo.tsx
@@ -45,6 +45,7 @@ function OptionInfo({cardData, setNewIndex, option}: cardDataProps) {
           cardData={cardData}
           isSaved={isSaved}
           setNewIndex={setNewIndex}
+          option={option}
         ></OptionCardList>
         <ModalWrapper ref={modalRef} $isopen={isModalOpen.toString()}>
           <Modal onClick={handleModalView}></Modal>
@@ -59,7 +60,7 @@ function OptionInfo({cardData, setNewIndex, option}: cardDataProps) {
   );
 }
 
-export default React.memo(OptionInfo);
+export default OptionInfo;
 
 const Wrapper = styled.div`
   ${flexCenter}


### PR DESCRIPTION
OptionCardList에 Context로 option을 참조하고 있었습니다. option이 변경될 때, Content 컴포넌트와 OptionCardList가 다시 렌더링 되기 때문에, 이전에 가지고 있던 cardData를 사용해 Detail API를 호출했습니다.

예를 들어 휠 카테고리의 경우 4가지의 옵션을 선택할 수 있습니다. 휠 카테고리에서 옵션의 개수가 적은 파워트레인과 같은 카테고리로 이동할 경우
휠 카테고리의 데이터를 사용해 OptionCardList를 렌더링이 먼저 진행되기 때문에 발생한 문제입니다.

```js
export default React.memo(OptionCardList, (prevProps, nextProps) => {
  return prevProps.cardData === nextProps.cardData;
});
```

따라서 OptionCardList에서 `memo`를 사용해서 전달된 cardData가 다를 때만 다시 렌더링되도록하여 해결했습니다.