### PR TITLE
[BE] 하위 옵션이 있는 추가 옵션의 상세 정보 API 오류 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/information/controller/DetailController.java
+++ b/backend/src/main/java/com/example/backend/domain/information/controller/DetailController.java
@@ -13,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/detail")
 @RequiredArgsConstructor
@@ -35,13 +37,13 @@ public class DetailController {
 
     @Order(1)
     @GetMapping("/additional-option/{id}")
-    public ResponseEntity<ResponseDto<DetailResponse>> returnAdditionalOptionDetail (
-            @PathVariable("id") long targetId
+    public ResponseEntity<ResponseDto<List<DetailResponse>>> returnAdditionalOptionDetail (
+            @PathVariable("id") long optionId
     ){
-        Long detailId = additionalOptionService.findDetailId(targetId);
-        DetailResponse result = detailService.getDetailById(detailId);
+        List<Long> detailIdList = additionalOptionService.findDetailId(optionId);
+        List<DetailResponse> result = detailService.getOptionDetailById(detailIdList);
 
-        ResponseDto<DetailResponse> body = ResponseDto.of(result, ResultCode.SUCCESS);
+        ResponseDto<List<DetailResponse>> body = ResponseDto.of(result, ResultCode.SUCCESS);
         return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 

--- a/backend/src/main/java/com/example/backend/domain/information/model/option/repository/AdditionalOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/information/model/option/repository/AdditionalOptionRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 public interface AdditionalOptionRepository extends CrudRepository<AdditionalOption, Long> {
     @Query("SELECT * FROM ADDITIONAL_OPTION ao WHERE ao.category = :category AND ao.top_option_id IS NULL")
     List<AdditionalOption> findAllByCategoryAndTopOptionIdIsNull(String category);
-    @Query("SELECT detail_id FROM ADDITIONAL_OPTION WHERE id = :id")
-    Long findDetailIdById(long id);
+    @Query("SELECT detail_id FROM ADDITIONAL_OPTION WHERE detail_id IS NOT NULL AND id = :id OR top_option_id = :id")
+    List<Long> findDetailIdById(long id);
 }

--- a/backend/src/main/java/com/example/backend/domain/information/service/AdditionalOptionService.java
+++ b/backend/src/main/java/com/example/backend/domain/information/service/AdditionalOptionService.java
@@ -21,7 +21,7 @@ public class AdditionalOptionService {
         return all.stream().map(informationMapper::map).collect(Collectors.toList());
     }
 
-    public Long findDetailId(long id) {
+    public List<Long> findDetailId(long id) {
         return repository.findDetailIdById(id);
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/information/service/DetailService.java
+++ b/backend/src/main/java/com/example/backend/domain/information/service/DetailService.java
@@ -8,6 +8,8 @@ import com.example.backend.domain.information.model.option.repository.DetailRepo
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -19,5 +21,15 @@ public class DetailService {
         Optional<Detail> target = repository.findById(id);
         if (target.isEmpty()) throw new RestApiException(ResultCode.NO_DETAIL_EXIST_FOR_ID);
         return new DetailResponse(target.get());
+    }
+
+    public List<DetailResponse> getOptionDetailById(List<Long> detailIdList) {
+        List<DetailResponse> detailResponseList = new ArrayList<>();
+        for (Long detailId : detailIdList) {
+            Optional<Detail> detail = repository.findById(detailId);
+            if (detail.isEmpty()) throw new RestApiException(ResultCode.NO_DETAIL_EXIST_FOR_ID);
+            detailResponseList.add(new DetailResponse(detail.get()));
+        }
+        return detailResponseList;
     }
 }


### PR DESCRIPTION
## 🔖 관련 이슈
- #167

## 📝 구현 사항
- 추가 옵션의 상세 정보 API 반환 구조 회의
- 정해진 구조에 맞게 API 수정
<img width="844" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/48046928/b6100c2d-7088-462d-99d4-83b0da3f63dc">
원래 쿼리 시 반환값
<img width="819" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/48046928/781fc0d5-f06f-4ff2-ac38-fdb534f1d21d">
수정 후 반환값

## 📌 하고싶은 말
- 쿼리만 조금 손봤어용
