### PR TITLE
[iOS] 내차만들기 옵션 선택시 배너 이미지 표시

### DIFF
--- a/iOS_H3/iOS_H3/Source/Domain/Model/OptionCardInfo.swift
+++ b/iOS_H3/iOS_H3/Source/Domain/Model/OptionCardInfo.swift
@@ -12,7 +12,7 @@ struct OptionCardInfo: Hashable {
     let title: String
     let subTitle: String
     let priceString: String     // 예시) "+ 100,000원"
-    let bannerImageURL: URL    // 옵션 카드 상단 큰 이미지
+    let bannerImageURL: URL?    // 옵션 카드 상단 큰 이미지
     let iconImageURL: URL?          // 내장 색상 옵션에만 존재하는 이미지
     let color: URColor?
     let hasMoreInfo: Bool       // 자세히보기 여부
@@ -22,7 +22,7 @@ struct OptionCardInfo: Hashable {
         title: String,
         subTitle: String,
         priceString: String,
-        bannerImageURL: URL,
+        bannerImageURL: URL? = nil,
         iconImageURL: URL? = nil,
         color: URColor? = nil,
         hasMoreInfo: Bool = false,

--- a/iOS_H3/iOS_H3/Source/Domain/Model/URColor.swift
+++ b/iOS_H3/iOS_H3/Source/Domain/Model/URColor.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct URColor: Hashable {
-    let red: Int8
-    let green: Int8
-    let blue: Int8
+    let red: UInt8
+    let green: UInt8
+    let blue: UInt8
 }

--- a/iOS_H3/iOS_H3/Source/Extensions/UIImageView+.swift
+++ b/iOS_H3/iOS_H3/Source/Extensions/UIImageView+.swift
@@ -9,7 +9,10 @@ import UIKit
 
 extension UIImageView {
     func loadCachedImage(of url: URL?, showLoading: Bool = true) {
-        guard let url else { return }
+        guard let url else {
+            image = .remove
+            return
+        }
 
         let key = url.lastPathComponent
         if let cachedImage = ImageCacheManager.shared.object(forKey: key as NSString) {

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -33,6 +33,8 @@ final class CarMakingViewController: UIViewController {
 
     private let stepDidChanged = CurrentValueSubject<CarMakingStep, Never>(.powertrain)
 
+    private let optionDidSelected = PassthroughSubject<(step: CarMakingStep, optionIndex: Int), Never>()
+
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Lifecycles
@@ -68,7 +70,8 @@ extension CarMakingViewController {
     private func bind() {
         let input = CarMakingViewModel.Input(
             viewDidLoad: viewDidLoadSubject,
-            carMakingStepDidChanged: stepDidChanged
+            carMakingStepDidChanged: stepDidChanged,
+            optionDidSelected: optionDidSelected
         )
         let output = viewModel.transform(input)
 
@@ -81,6 +84,12 @@ extension CarMakingViewController {
         output.currentStepInfo
             .sink { [weak self] info in
                 self?.updateCurrentStepInfo(with: info)
+            }
+            .store(in: &cancellables)
+
+        output.optionInfoDidUpdated
+            .sink { [weak self] optionInfo in
+                self?.carMakingContentView.updateOptionCard(with: optionInfo)
             }
             .store(in: &cancellables)
 
@@ -97,7 +106,7 @@ extension CarMakingViewController {
     }
 
     private func updateCurrentStepInfo(with info: CarMakingStepInfo) {
-        carMakingContentView.updateCurrentStepInfo(info)
+        carMakingContentView.configureCurrentStep(with: info)
     }
 
     private func showIndicator(_ show: Bool) {
@@ -137,6 +146,12 @@ extension CarMakingViewController: CarMakingContentViewDelegate {
     func carMakingContentView(stepDidChanged stepIndex: Int) {
         if let step = CarMakingStep(rawValue: stepIndex) {
             stepDidChanged.send(step)
+        }
+    }
+
+    func carMakingContentView(optionDidSelectedAt optionIndex: Int, in stepIndex: Int) {
+        if let step = CarMakingStep(rawValue: stepIndex) {
+            optionDidSelected.send((step, optionIndex))
         }
     }
 }

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
@@ -15,6 +15,7 @@ final class CarMakingViewModel {
     struct Input {
         var viewDidLoad: PassthroughSubject<Void, Never>
         var carMakingStepDidChanged: CurrentValueSubject<CarMakingStep, Never>
+        var optionDidSelected: PassthroughSubject<(step: CarMakingStep, optionIndex: Int), Never>
     }
 
     // MARK: - Output
@@ -22,6 +23,7 @@ final class CarMakingViewModel {
     struct Output {
         var estimateSummary = PassthroughSubject<EstimateSummary, Never>()
         var currentStepInfo = CurrentValueSubject<CarMakingStepInfo, Never>(CarMakingStepInfo(step: .powertrain))
+        var optionInfoDidUpdated = PassthroughSubject<[OptionCardInfo], Never>()
         var showIndicator = PassthroughSubject<Bool, Never>()
     }
 
@@ -48,6 +50,24 @@ final class CarMakingViewModel {
                 let carMakingStepInfo = requestCurrentStepInfo(step)
                 output.currentStepInfo.send(carMakingStepInfo)
             })
+            .store(in: &cancellables)
+
+        input.optionDidSelected
+            .sink { (step, optionIndex) in
+                let stepIndex = step.rawValue
+
+                switch step {
+                case .optionSelection:
+                    CarMakingMockData.mockOption[stepIndex][optionIndex].isSelected.toggle()
+                default:
+                    CarMakingMockData.mockOption[stepIndex].enumerated().forEach { (optionIndex, _) in
+                        CarMakingMockData.mockOption[stepIndex][optionIndex].isSelected = false
+                    }
+                    CarMakingMockData.mockOption[stepIndex][optionIndex].isSelected = true
+                }
+
+                output.optionInfoDidUpdated.send(CarMakingMockData.mockOption[stepIndex])
+            }
             .store(in: &cancellables)
 
         return output
@@ -83,7 +103,7 @@ struct CarMakingMockData {
          "https://itimg.chosun.com/sitedata/image/202112/03/2021120301496_0.jpg"
     ].compactMap { URL(string: $0) }
 
-    static let mockOption = [
+    static var mockOption = [
             [OptionCardInfo.init(title: "디젤 2.2",
                                  subTitle: "구매자의 63%가 선택한",
                                  priceString: "+ 3,456,789원",
@@ -153,8 +173,7 @@ struct CarMakingMockData {
             [OptionCardInfo.init(title: "가솔린 3.8",
                                  subTitle: "구매자의 63%가 선택한",
                                  priceString: "+ 0 원",
-                                 bannerImageURL: mockURL[1],
-                                 isSelected: true),
+                                 bannerImageURL: mockURL[1]),
              OptionCardInfo.init(title: "가솔린 3.8",
                                  subTitle: "구매자의 63%가 선택한",
                                  priceString: "+ 0 원",

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -77,7 +77,7 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
         guard let optionButtonListView = optionButtonListView as? OptionCardButtonListViewable else {
             return
         }
-        optionButtonListView.updateAllViews(with: optionInfoArray)
+        optionButtonListView.configure(with: optionInfoArray)
     }
 
 }

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -131,10 +131,11 @@ extension CarMakingCollectionViewCell: OptionCardButtonListViewDelegate {
     }
 }
 
+// MARK: - Setup
+
 extension CarMakingCollectionViewCell {
     private func setupViews() {
         addSubViews()
-        self.backgroundView?.backgroundColor = .blue
         setupImageView()
         setupDescriptionLabel()
         setupButtonListView()

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -10,6 +10,7 @@ import UIKit
 class CarMakingCollectionViewCell: UICollectionViewCell {
 
     // MARK: - UI properties
+
     enum Constants {
         static let descriptionLabelLeadingMargin: CGFloat = 20.0
         static let optionImageViewBottomMargin: CGFloat = 15.0
@@ -36,13 +37,16 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
 
     let optionButtonListView: UIView
 
+    // MARK: - Properites
+
+    private var bannerImagesOfOption: [URL?] = []
+
     // MARK: - Lifecycles
 
     override init(frame: CGRect) {
         optionButtonListView = TwoOptionCardButtonView()
         super.init(frame: frame)
         setupViews()
-
     }
 
     required init?(coder: NSCoder) {
@@ -54,6 +58,7 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
     init(frame: CGRect = .zero, buttonListViewable: OptionCardButtonListViewable) {
         optionButtonListView = buttonListViewable
         super.init(frame: frame)
+        buttonListViewable.delegate = self
         setupViews()
     }
 
@@ -83,6 +88,7 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
     }
 
     func configure(optionInfoArray: [OptionCardInfo]) {
+        bannerImagesOfOption = optionInfoArray.map { $0.bannerImageURL }
         guard let optionButtonListView = optionButtonListView as? OptionCardButtonListViewable else {
             return
         }
@@ -94,6 +100,29 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
             return
         }
         optionButtonListView.reloadOptionCards(with: optionInfoArray)
+    }
+}
+
+// MARK: - OptionCardButtonListView Delegate
+
+extension CarMakingCollectionViewCell: OptionCardButtonListViewDelegate {
+
+    func optionCardButtonListView(
+        _ optionCardButtonListView: OptionCardButtonListViewable,
+        didSelectOptionAt index: Int
+    ) {
+        if optionCardButtonListView is TwoOptionCardButtonView {
+            configure(bannerImageURL: bannerImagesOfOption[index])
+        }
+    }
+
+    func optionCardButtonListView(
+        _ optionCardButtonListView: OptionCardButtonListViewable,
+        didDisplayOptionAt index: Int
+    ) {
+        if optionCardButtonListView is MultiOptionCardButtonView {
+            configure(bannerImageURL: bannerImagesOfOption[index])
+        }
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -73,6 +73,10 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
                                                 font: Fonts.mediumTitle3 ?? .systemFont(ofSize: 10.0))
     }
 
+    func configure(bannerImageURL: URL?) {
+        optionImageView.loadCachedImage(of: bannerImageURL)
+    }
+
     func configure(optionInfoArray: [OptionCardInfo]) {
         guard let optionButtonListView = optionButtonListView as? OptionCardButtonListViewable else {
             return

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 class CarMakingCollectionViewCell: UICollectionViewCell {
 
@@ -41,6 +42,8 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
 
     private var bannerImagesOfOption: [URL?] = []
 
+    var optionDidSelected = PassthroughSubject<Int, Never>()
+
     // MARK: - Lifecycles
 
     override init(frame: CGRect) {
@@ -64,6 +67,7 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         optionImageView.image = nil
+        optionDidSelected = PassthroughSubject<Int, Never>()
     }
 
     // MARK: - Helpers
@@ -111,6 +115,7 @@ extension CarMakingCollectionViewCell: OptionCardButtonListViewDelegate {
         _ optionCardButtonListView: OptionCardButtonListViewable,
         didSelectOptionAt index: Int
     ) {
+        optionDidSelected.send(index)
         if optionCardButtonListView is TwoOptionCardButtonView {
             configure(bannerImageURL: bannerImagesOfOption[index])
         }

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -89,6 +89,12 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
         optionButtonListView.configure(with: optionInfoArray)
     }
 
+    func update(optionInfoArray: [OptionCardInfo]) {
+        guard let optionButtonListView = optionButtonListView as? OptionCardButtonListViewable else {
+            return
+        }
+        optionButtonListView.reloadOptionCards(with: optionInfoArray)
+    }
 }
 
 extension CarMakingCollectionViewCell {

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -65,6 +65,11 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
     func configure(carMakingStepInfo: CarMakingStepInfo) {
         configure(carMakingStepTitle: carMakingStepInfo.step.title)
         configure(optionInfoArray: carMakingStepInfo.optionCardInfoArray)
+
+        if !carMakingStepInfo.optionCardInfoArray.isEmpty {
+            let optionIndexToShowBanner = carMakingStepInfo.optionCardInfoArray.firstIndex { $0.isSelected } ?? 0
+            configure(bannerImageURL: carMakingStepInfo.optionCardInfoArray[optionIndexToShowBanner].bannerImageURL)
+        }
     }
 
     func configure(carMakingStepTitle: String) {

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
@@ -95,19 +95,12 @@ class CarMakingContentView<Section: CarMakingSectionType>: UIView, UICollectionV
         updateCollectionViewSnapshot(ofItem: info)
     }
 
+    func updateOptionCard(with info: [OptionCardInfo]) {
         let indexPathOfCurrentStep = Section.indexPath(for: currentStep)
-        guard let section = Section(sectionIndex: indexPathOfCurrentStep.section) else {
+        guard let cell = collectionView.cellForItem(at: indexPathOfCurrentStep) as? CarMakingCollectionViewCell else {
             return
         }
-
-        var sectionItems = snapshot.itemIdentifiers(inSection: section)
-        snapshot.deleteItems(sectionItems)
-
-        let currentItemIndex = indexPathOfCurrentStep.row
-        sectionItems[currentItemIndex] = info
-
-        snapshot.appendItems(sectionItems, toSection: section)
-        collectionViewDataSource.apply(snapshot)
+        cell.update(optionInfoArray: info)
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
@@ -92,7 +92,8 @@ class CarMakingContentView<Section: CarMakingSectionType>: UIView, UICollectionV
     }
 
     func updateCurrentStepInfo(_ info: CarMakingStepInfo) {
-        var snapshot = collectionViewDataSource.snapshot()
+        updateCollectionViewSnapshot(ofItem: info)
+    }
 
         let indexPathOfCurrentStep = Section.indexPath(for: currentStep)
         guard let section = Section(sectionIndex: indexPathOfCurrentStep.section) else {
@@ -120,6 +121,24 @@ extension CarMakingContentView {
     private func moveCollectionView(to index: Int) {
         let indexPath = Section.indexPath(for: index)
         collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+    }
+
+    private func updateCollectionViewSnapshot(ofItem info: CarMakingStepInfo) {
+        var snapshot = collectionViewDataSource.snapshot()
+
+        let indexPathOfCurrentStep = Section.indexPath(for: currentStep)
+        guard let section = Section(sectionIndex: indexPathOfCurrentStep.section) else {
+            return
+        }
+
+        var sectionItems = snapshot.itemIdentifiers(inSection: section)
+        snapshot.deleteItems(sectionItems)
+
+        let currentItemIndex = indexPathOfCurrentStep.row
+        sectionItems[currentItemIndex] = info
+
+        snapshot.appendItems(sectionItems, toSection: section)
+        collectionViewDataSource.apply(snapshot)
     }
 }
 
@@ -211,7 +230,7 @@ extension CarMakingContentView {
 
 }
 
-// MARK: - UICollectionViewDelegateFlowLayout
+// MARK: - UICollectionView DelegateFlowLayout
 
 class FlowLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     let progressBarHeight = 26.0

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
@@ -91,7 +91,7 @@ class CarMakingContentView<Section: CarMakingSectionType>: UIView, UICollectionV
         currentStep -= 1
     }
 
-    func updateCurrentStepInfo(_ info: CarMakingStepInfo) {
+    func configureCurrentStep(with info: CarMakingStepInfo) {
         updateCollectionViewSnapshot(ofItem: info)
     }
 

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentViewController.swift
@@ -92,13 +92,16 @@ extension CarMakingContentViewController: CarMakingContentViewDelegate {
 
     func carMakingContentView(stepDidChanged stepIndex: Int) {
         guard let step = CarMakingStep(rawValue: stepIndex) else { return }
-        let indexPath = PageSection.indexPath(for: stepIndex)
 
         let stepInfo = CarMakingStepInfo(
             step: step,
             optionCardInfoArray: CarMakingContentMockData.mockOption[stepIndex]
         )
-        carMakingContentView.updateCurrentStepInfo(stepInfo)
+        carMakingContentView.configureCurrentStep(with: stepInfo)
+    }
+
+    func carMakingContentView(optionDidSelectedAt optionIndex: Int, in stepIndex: Int) {
+        CarMakingContentMockData.mockOption[stepIndex][optionIndex].isSelected.toggle()
     }
 }
 
@@ -114,7 +117,7 @@ struct CarMakingContentMockData {
          "https://itimg.chosun.com/sitedata/image/202112/03/2021120301496_0.jpg"
     ].map { URL(string: $0)! }
 
-    static let mockOption = [
+    static var mockOption = [
             [OptionCardInfo.init(title: "디젤 2.2",
                                  subTitle: "구매자의 63%가 선택한",
                                  priceString: "+ 3,456,789원",

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
@@ -41,7 +41,7 @@ final class MultiOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     private var buttonTapCancellableByIndex: [Int: AnyCancellable] = [:]
 
-    weak var delegate: MultiOptionCardButtonViewDelegate?
+    weak var delegate: OptionCardButtonListViewDelegate?
 
     // MARK: - Lifecycles
 
@@ -161,7 +161,7 @@ extension MultiOptionCardButtonView {
             buttonTapCancellableByIndex[indexPath.row] = cell.buttonTapSubject
                 .sink { [weak self] in
                     guard let self else { return }
-                    delegate?.optionCardButtonDidTapped(index: indexPath.row)
+                    delegate?.optionCardButtonListView(self, didSelectOptionAt: indexPath.row)
                 }
 
             return cell

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
@@ -43,6 +43,8 @@ final class MultiOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     weak var delegate: OptionCardButtonListViewDelegate?
 
+    private var willDisplayingCellIndexPath = IndexPath()
+
     // MARK: - Lifecycles
 
     init(frame: CGRect = .zero, carMakingMode: CarMakingMode) {
@@ -96,6 +98,29 @@ extension MultiOptionCardButtonView: OptionCardButtonDelegate {
     }
 }
 
+// MARK: - UICollectionView Delegate
+
+extension MultiOptionCardButtonView: UICollectionViewDelegate {
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        willDisplayingCellIndexPath = indexPath
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didEndDisplaying cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        if willDisplayingCellIndexPath != indexPath {
+            delegate?.optionCardButtonListView(self, didDisplayOptionAt: willDisplayingCellIndexPath.row)
+        }
+    }
+}
+
 // MARK: - Setup CollectionView
 
 extension MultiOptionCardButtonView {
@@ -103,6 +128,7 @@ extension MultiOptionCardButtonView {
     private func setupOptionCardCollectionView() {
         optionCardCollectionView = UICollectionView(frame: .zero, collectionViewLayout: createCollectionViewLayout())
         optionCardCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        optionCardCollectionView.delegate = self
         optionCardCollectionView.isScrollEnabled = true
         optionCardCollectionView.bounces = false
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
@@ -71,7 +71,7 @@ final class MultiOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     // MARK: - Helpers
 
-    func updateAllViews(with cardInfos: [OptionCardInfo]) {
+    func configure(with cardInfos: [OptionCardInfo]) {
         dotIndicator.numberOfPages = cardInfos.count
         updateSnapshot(item: cardInfos)
     }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
@@ -75,6 +75,16 @@ final class MultiOptionCardButtonView: UIView, OptionCardButtonListViewable {
         dotIndicator.numberOfPages = cardInfos.count
         updateSnapshot(item: cardInfos)
     }
+
+    func reloadOptionCards(with cardInfos: [OptionCardInfo]) {
+        cardInfos.enumerated().forEach { (index, info) in
+            let indexPath = IndexPath(row: index, section: 0)
+            guard let cell = optionCardCollectionView.cellForItem(at: indexPath) as? OptionCardCell else {
+                return
+            }
+            cell.configure(carMakingMode: carMakingMode, info: info)
+        }
+    }
 }
 
 // MARK: - OptionCardButton Delegate

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonView.swift
@@ -77,9 +77,11 @@ final class MultiOptionCardButtonView: UIView, OptionCardButtonListViewable {
     }
 }
 
+// MARK: - OptionCardButton Delegate
+
 extension MultiOptionCardButtonView: OptionCardButtonDelegate {
 
-    func moreInfoButtonDidTapped() {
+    func optionCardButtonMoreInfoButtonDidTap(_ optionCardButton: OptionCardButton) {
         print("[MultiOptionCardButtonView]", #function, "- show alert 구현 필요")
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonViewController.swift
@@ -93,9 +93,22 @@ final class MultiOptionCardButtonViewController: UIViewController {
     }
 }
 
-extension MultiOptionCardButtonViewController: MultiOptionCardButtonViewDelegate {
-    func optionCardButtonDidTapped(index: Int) {
+// MARK: - OptionCardButtonListView Delegate
+
+extension MultiOptionCardButtonViewController: OptionCardButtonListViewDelegate {
+
+    func optionCardButtonListView(
+        _ optionCardButtonListView: OptionCardButtonListViewable,
+        didSelectOptionAt index: Int
+    ) {
         cardInfos[index].isSelected.toggle()
         selfModeMultiOptionCardButtonView.configure(with: cardInfos)
+    }
+
+    func optionCardButtonListView(
+        _ optionCardButtonListView: OptionCardButtonListViewable,
+        didDisplayOptionAt index: Int
+    ) {
+
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/MultiOptionCardButtonViewController.swift
@@ -18,14 +18,14 @@ final class MultiOptionCardButtonViewController: UIViewController {
 
     private lazy var selfModeMultiOptionCardButtonView: MultiOptionCardButtonView = {
         let view = MultiOptionCardButtonView(carMakingMode: .selfMode)
-        view.updateAllViews(with: self.cardInfos)
+        view.configure(with: self.cardInfos)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
 
     private lazy var guideModeMultiOptionCardButtonView: MultiOptionCardButtonView = {
         let view = MultiOptionCardButtonView(carMakingMode: .guideMode)
-        view.updateAllViews(with: self.cardInfos)
+        view.configure(with: self.cardInfos)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -96,6 +96,6 @@ final class MultiOptionCardButtonViewController: UIViewController {
 extension MultiOptionCardButtonViewController: MultiOptionCardButtonViewDelegate {
     func optionCardButtonDidTapped(index: Int) {
         cardInfos[index].isSelected.toggle()
-        selfModeMultiOptionCardButtonView.updateAllViews(with: cardInfos)
+        selfModeMultiOptionCardButtonView.configure(with: cardInfos)
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardButtonListViewable.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardButtonListViewable.swift
@@ -8,5 +8,5 @@
 import UIKit
 
 protocol OptionCardButtonListViewable: UIView {
-    func updateAllViews(with cardInfos: [OptionCardInfo])
+    func configure(with cardInfos: [OptionCardInfo])
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardButtonListViewable.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardButtonListViewable.swift
@@ -19,5 +19,8 @@ protocol OptionCardButtonListViewDelegate: AnyObject {
 }
 
 protocol OptionCardButtonListViewable: UIView {
+    var delegate: OptionCardButtonListViewDelegate? { get set }
+
     func configure(with cardInfos: [OptionCardInfo])
+    func reloadOptionCards(with cardInfos: [OptionCardInfo])
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardButtonListViewable.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardButtonListViewable.swift
@@ -7,6 +7,17 @@
 
 import UIKit
 
+protocol OptionCardButtonListViewDelegate: AnyObject {
+    func optionCardButtonListView(
+        _ optionCardButtonListView: OptionCardButtonListViewable,
+        didSelectOptionAt index: Int
+    )
+    func optionCardButtonListView(
+        _ optionCardButtonListView: OptionCardButtonListViewable,
+        didDisplayOptionAt index: Int
+    )
+}
+
 protocol OptionCardButtonListViewable: UIView {
     func configure(with cardInfos: [OptionCardInfo])
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
@@ -56,7 +56,8 @@ final class OptionCardCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        optionCardButton.isSelected = false
+
+        initOptionCardButton()
         buttonTapSubject = PassthroughSubject<Void, Never>()
     }
 
@@ -86,5 +87,12 @@ extension OptionCardCell {
     @objc
     private func optionButtonDidTapped() {
         buttonTapSubject.send(())
+    }
+
+    private func initOptionCardButton() {
+        optionCardButton.isSelected = false
+        optionCardButton.setColor(nil)
+        optionCardButton.setImage(url: nil)
+        optionCardButton.showMoreInfoButton(false)
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -75,6 +75,8 @@ extension TwoOptionCardButtonView: OptionCardButtonDelegate {
     }
 }
 
+// MARK: - Setup
+
 extension TwoOptionCardButtonView {
 
     private func setupOptionCardButtons() {
@@ -85,17 +87,28 @@ extension TwoOptionCardButtonView {
         }
     }
 
-    private func setupViews() {
-        addSubviews()
-        setupConstraints()
-    }
-
     @objc
     private func optionCardButtonDidTapped(_ sender: UIButton) {
         guard let selectedOptionIndex = optionCardButtons.firstIndex(where: { $0 == sender }) else {
             return
         }
         selectOption(index: selectedOptionIndex)
+    }
+
+    private func selectOption(index: Int) {
+        if !isValidateIndex(index) { return }
+        delegate?.optionCardButtonListView(self, didSelectOptionAt: index)
+    }
+
+    private func isValidateIndex(_ index: Int) -> Bool {
+        0..<optionCardButtons.count ~= index
+    }
+
+    // MARK: - Setup Views
+
+    private func setupViews() {
+        addSubviews()
+        setupConstraints()
     }
 
     private func addSubviews() {
@@ -123,17 +136,5 @@ extension TwoOptionCardButtonView {
             optionCardButtons[1].trailingAnchor.constraint(equalTo: self.trailingAnchor),
             optionCardButtons[1].bottomAnchor.constraint(equalTo: self.optionCardButtons[0].bottomAnchor)
         ])
-    }
-
-    private func selectOption(index: Int) {
-        if !isValidateIndex(index) { return }
-
-        optionCardButtons[selectedButtonIndex].isSelected = false
-        optionCardButtons[index].isSelected = true
-        selectedButtonIndex = index
-    }
-
-    private func isValidateIndex(_ index: Int) -> Bool {
-        0..<optionCardButtons.count ~= index
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -74,7 +74,7 @@ extension TwoOptionCardButtonView: OptionCardButtonDelegate {
 
     func optionCardButtonMoreInfoButtonDidTap(_ optionCardButton: OptionCardButton) {
         if let index = optionCardButtons.firstIndex(of: optionCardButton) {
-            delegate?.optionCardButtonListView(self, moreButtonDidTappedAt: index)
+//            delegate?.optionCardButtonListView(self, moreButtonDidTappedAt: index)
         }
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -19,7 +19,7 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     // MARK: - Properties
 
-    private var selectedButtonIndex = 0
+    weak var delegate: OptionCardButtonListViewDelegate?
 
     // MARK: - LifeCycles
 
@@ -61,6 +61,10 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
             if cardInfos.count <= index { return }
             configureOptionCard(at: index, with: cardInfos[index])
         }
+    }
+
+    func reloadOptionCards(with cardInfos: [OptionCardInfo]) {
+        configure(with: cardInfos)
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -60,7 +60,7 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
     }
 
     /// 카드 info에 따라 모든 옵션 카드의 view를 업데이트
-    func updateAllViews(with cardInfos: [OptionCardInfo]) {
+    func configure(with cardInfos: [OptionCardInfo]) {
         optionCardButtons.enumerated().forEach { (index, _) in
             if cardInfos.count <= index { return }
             updateView(index: index, with: cardInfos[index])

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -73,8 +73,7 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 extension TwoOptionCardButtonView: OptionCardButtonDelegate {
 
     func optionCardButtonMoreInfoButtonDidTap(_ optionCardButton: OptionCardButton) {
-        if let index = optionCardButtons.firstIndex(of: optionCardButton) {
-//            delegate?.optionCardButtonListView(self, moreButtonDidTappedAt: index)
+        if let _ = optionCardButtons.firstIndex(of: optionCardButton) {
         }
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -68,10 +68,14 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
     }
 }
 
+// MARK: - OptionCardButton Delegate
+
 extension TwoOptionCardButtonView: OptionCardButtonDelegate {
 
-    func moreInfoButtonDidTapped() {
-        print("[TwoOptionCardButtonView]", #function, "- show alert 구현 필요")
+    func optionCardButtonMoreInfoButtonDidTap(_ optionCardButton: OptionCardButton) {
+        if let index = optionCardButtons.firstIndex(of: optionCardButton) {
+            delegate?.optionCardButtonListView(self, moreButtonDidTappedAt: index)
+        }
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -50,20 +50,16 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
     // MARK: - Helpers
 
     /// index에 해당하는 옵션 카드의 view를 업데이트
-    func updateView(index: Int, with cardInfo: OptionCardInfo) {
+    func configureOptionCard(at index: Int, with cardInfo: OptionCardInfo) {
         if !isValidateIndex(index) { return }
-
         optionCardButtons[index].update(cardInfo: cardInfo)
-        if cardInfo.isSelected {
-            selectOption(index: index)
-        }
     }
 
     /// 카드 info에 따라 모든 옵션 카드의 view를 업데이트
     func configure(with cardInfos: [OptionCardInfo]) {
         optionCardButtons.enumerated().forEach { (index, _) in
             if cardInfos.count <= index { return }
-            updateView(index: index, with: cardInfos[index])
+            configureOptionCard(at: index, with: cardInfos[index])
         }
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -73,8 +73,6 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 extension TwoOptionCardButtonView: OptionCardButtonDelegate {
 
     func optionCardButtonMoreInfoButtonDidTap(_ optionCardButton: OptionCardButton) {
-        if let _ = optionCardButtons.firstIndex(of: optionCardButton) {
-        }
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonViewController.swift
@@ -19,7 +19,7 @@ final class TwoOptionCardButtonViewController: UIViewController {
 
     private let guideModeTwoOptionCardButtonView: TwoOptionCardButtonView = {
         let view = TwoOptionCardButtonView(carMakingMode: .guideMode)
-        view.updateOptionCard(
+        view.configureOptionCard(
             at: 0,
             with: CarMakingContentMockData.mockOption[0][0]
         )

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonViewController.swift
@@ -19,8 +19,8 @@ final class TwoOptionCardButtonViewController: UIViewController {
 
     private let guideModeTwoOptionCardButtonView: TwoOptionCardButtonView = {
         let view = TwoOptionCardButtonView(carMakingMode: .guideMode)
-        view.updateView(
-            index: 0,
+        view.updateOptionCard(
+            at: 0,
             with: CarMakingContentMockData.mockOption[0][0]
         )
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonViewController.swift
@@ -30,14 +30,14 @@ final class TwoOptionCardButtonViewController: UIViewController {
     private let twoOptionCardButtonViewWithData: TwoOptionCardButtonView = {
         let view = TwoOptionCardButtonView(carMakingMode: .selfMode)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.updateAllViews(with: CarMakingContentMockData.mockOption[0])
+        view.configure(with: CarMakingContentMockData.mockOption[0])
         return view
     }()
 
     private let moreInfoVersionView: TwoOptionCardButtonView = {
         let view = TwoOptionCardButtonView(carMakingMode: .selfMode)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.updateAllViews(with: CarMakingContentMockData.mockOption[0])
+        view.configure(with: CarMakingContentMockData.mockOption[0])
         return view
     }()
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol OptionCardButtonDelegate: AnyObject {
-    func moreInfoButtonDidTapped()
+    func optionCardButtonMoreInfoButtonDidTap(_ optionCardButton: OptionCardButton)
 }
 
 class OptionCardButton: UIButton {
@@ -380,6 +380,6 @@ extension OptionCardButton {
 
     @objc
     private func moreInfoButtonTapped() {
-        delegate?.moreInfoButtonDidTapped()
+        delegate?.optionCardButtonMoreInfoButtonDidTap(self)
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
@@ -153,7 +153,7 @@ class OptionCardButton: UIButton {
         self.optionTitleLabel.text = optionTitle
         self.optionSubTitleLabel.text = optionSubTitle
         self.priceLabel.text = price
-        self.moreInfoButton.isHidden = !hasMoreInfo
+        showMoreInfoButton(hasMoreInfo)
         setupViews()
         addMoreInfoButtonTarget()
         setColor(color)
@@ -170,7 +170,7 @@ class OptionCardButton: UIButton {
             self.optionTitleLabel.text = cardInfo.title
             self.optionSubTitleLabel.text = cardInfo.subTitle
             self.priceLabel.text = cardInfo.priceString
-            self.moreInfoButton.isHidden = !cardInfo.hasMoreInfo
+            showMoreInfoButton(cardInfo.hasMoreInfo)
             isSelected = cardInfo.isSelected
             setColor(cardInfo.color)
             setImage(url: cardInfo.iconImageURL)
@@ -207,6 +207,10 @@ class OptionCardButton: UIButton {
         if let url {
             optionImageView.loadCachedImage(of: url)
         }
+    }
+
+    func showMoreInfoButton(_ isShow: Bool) {
+        moreInfoButton.isHidden = !isShow
     }
 
     func animateButton(title: String, description: String) {

--- a/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
@@ -156,8 +156,8 @@ class OptionCardButton: UIButton {
         self.moreInfoButton.isHidden = !hasMoreInfo
         setupViews()
         addMoreInfoButtonTarget()
-        if let color = color { setColor(UIColor(urColor: color)) }
-        if let url = image { setImage(url: url) }
+        setColor(color)
+        setImage(url: image)
     }
 
     // MARK: - Helpers
@@ -172,18 +172,18 @@ class OptionCardButton: UIButton {
             self.priceLabel.text = cardInfo.priceString
             self.moreInfoButton.isHidden = !cardInfo.hasMoreInfo
             isSelected = cardInfo.isSelected
-            if let color = cardInfo.color { setColor(UIColor(urColor: color)) }
-            if let url = cardInfo.iconImageURL {
-                setImage(url: url)
-            }
+            setColor(cardInfo.color)
+            setImage(url: cardInfo.iconImageURL)
         }
 
         updateButtonUI()
     }
 
-    func setColor(_ color: UIColor) {
-        colorView.backgroundColor = color
-        colorView.isHidden = false
+    func setColor(_ color: URColor?) {
+        colorView.isHidden = color == nil ? true: false
+        if let color {
+            colorView.backgroundColor = UIColor(urColor: color)
+        }
     }
 
     func setOptionTitle(_ title: String) {
@@ -202,9 +202,11 @@ class OptionCardButton: UIButton {
         tagListView.addTags(tags)
     }
 
-    func setImage(url: URL) {
-        optionImageView.loadCachedImage(of: url)
-        optionImageView.isHidden = false
+    func setImage(url: URL?) {
+        optionImageView.isHidden = url == nil ? true: false
+        if let url {
+            optionImageView.loadCachedImage(of: url)
+        }
     }
 
     func animateButton(title: String, description: String) {

--- a/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButtonViewController.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButtonViewController.swift
@@ -32,7 +32,7 @@ class OptionCardButtonViewController: UIViewController {
     // 셀프모드 외장 색상 버튼
     lazy var guideModeOuterColorButton: OptionCardButton = {
         let button = OptionCardButton(mode: .guideMode)
-        button.setColor(.blue)
+        button.setColor(URColor(red: 255, green: 167, blue: 36))
         return button
     }()
 
@@ -61,10 +61,10 @@ class OptionCardButtonViewController: UIViewController {
         self.guideModeBasicButton.setPrice("+ 3,456,789원")
 
         // 이미지 변경하기
-        // self.selfModeInnerButton.setImage(UIImage(named: ""), for: .normal)
+//         self.selfModeInnerColorButton.setImage(UIImage(named: ""), for: .normal)
 
         // 컬러 변경하기
-        self.guideModeOuterColorButton.setColor(.black)
+        self.guideModeOuterColorButton.setColor(URColor(red: 0, green: 0, blue: 0))
         // 태그 추가하기
         self.guideModeBasicButton.addTags(["효율 89%", "배터리 95%"])
         self.guideModeOuterColorButton.addTags(["효율 89%", "배터리 95%"])

--- a/iOS_H3/iOS_H3_UI/OptionListView/OptionListModeView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionListView/OptionListModeView.swift
@@ -86,7 +86,7 @@ final class OptionListModeView: UIView {
     }
 
     // MARK: - Helpers
-    func updateAllViews(with cardInfos: [OptionCardInfo]) {
+    func configure(with cardInfos: [OptionCardInfo]) {
         updateSnapshot(item: cardInfos)
     }
 }

--- a/iOS_H3/iOS_H3_UI/OptionListView/OptionListModeViewController.swift
+++ b/iOS_H3/iOS_H3_UI/OptionListView/OptionListModeViewController.swift
@@ -39,7 +39,7 @@ final class OptionListModeViewController: UIViewController {
 
         setupDelegate()
         setupViews()
-        self.selfModeOptionModeListView.updateAllViews(with: cardInfos)
+        self.selfModeOptionModeListView.configure(with: cardInfos)
     }
 
     // MARK: - Helpers
@@ -75,7 +75,7 @@ final class OptionListModeViewController: UIViewController {
 extension OptionListModeViewController: OptionListModeViewDelegate {
     func optionListModeView(with: OptionListModeView, didSelectedIndex: Int) {
         cardInfos[didSelectedIndex].isSelected.toggle()
-        selfModeOptionModeListView.updateAllViews(with: cardInfos)
+        selfModeOptionModeListView.configure(with: cardInfos)
     }
 
     func optionListModeViewDidTapImageModeButton(with: OptionListModeView) {


### PR DESCRIPTION
## 🔖 관련 이슈
- #156 

## 📝 구현 사항

### 내차만들기 옵션 선택시 배너 이미지 표시

- 투버튼의 경우 (즉 내차만들기 단계 중 파워트레인, 구동방식, 바디타입 단계), 옵션 선택 시 배너 이미지 업데이트
- 멀티버튼의 경우 (그 외 나머지 단계) 옵션 display 시점에 배너 이미지 업데이트

옵션 선택 시 이미지 업데이트 (투버튼) | 옵션 display 시 이미지 업데이트 (멀티버튼)
---|---
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-18 at 16 25 15](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/41dd844d-2794-4a8e-baaa-8f6d12f4104b) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-18 at 16 25 29](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/8a4161c4-f638-4a11-9ad0-ba33937d9d98)

<details>
<summary> 배너 이미지 표시 관련 이슈 1 </summary>

  **투버튼과 멀티버튼의 배너 이미지 변경 시점 다르다는 이슈**가 있었습니다.

  `투버튼`은 버튼이 선택되었을 때 이미지가 변경되고 `멀티버튼`은 버튼이 화면에 나타났을 때 이미지가 변경됩니다.

  그래서 우선 `OptionCardButtonListViewDelegate`를 구현하고 딜리게이트의 메소드로 `didSelectOptionAt`와 `didDisplayOptionAt`를 선언했습니다

  `OptionCardButtonListViewDelegate`를 채택한 `CarMakingCollectionViewCell`에서는
  
  - `didSelectOptionAt`, 즉 옵션 카드가 선택되면 TwoButtonView인지 확인 후 배너 이미지를 업데이트 해주고
  - `didDisplayOptionAt`, 즉 옵션 카드가 display 되면 MultiButtonView인지 확인 후 배너 이미지를 업데이트 해주었습니다.

</details>

<details>
<summary> 배너 이미지 표시 관련 이슈 2 </summary>

  옵션 선택 시 `optionCardInfo`의 `isSelected` 속성을 업데이트 하고 다시 그 카드 정보를 `OptionCardCollectionView`에 반영하여 화면을 업데이트 과정에 `diffableDataSource`의 `snapshot`을 사용함으로써 생긴 이슈가 있었습니다.

  만약 전체 옵션 카드가 4개라고 했을 때 4번째 옵션을 선택하면 선택 상태를 업데이트 한 후에도 4번째 옵션이 보여져야 하는데 
  스냅샷을 다시 적용하면서 `deleteItem` 후 `append` 하게 되면서 첫번째 옵션이 보여지는 문제가 있었습니다.
  
  따라서 옵션 선택 정보를 업데이트 시에는 snapshot을 이용하지 않고 
  다음과 같이 `cellForItem`을 이용하여 셀에 직접 접근해서 업데이트하여 문제를 해결했습니다

  ```swift
      func updateOptionCard(with info: [OptionCardInfo]) {
          let indexPathOfCurrentStep = Section.indexPath(for: currentStep)
          guard let cell = collectionView.cellForItem(at: indexPathOfCurrentStep) as? CarMakingCollectionViewCell else {
              return
          }
          cell.update(optionInfoArray: info)
      }
  ```

</details>

### 옵션 선택 기능 구현

- 내차만들기 단계 중 옵션 선택 단계만 여러 옵션 선택 가능. 혹은 0개 선택 가능
- 그외 단계는 여러 옵션 중 하나만 선택 가능

한 옵션만 선택 가능 | 옵션 선택 단계는 여러 옵션 선택 가능
---|---
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-18 at 16 27 04](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/4dc4de67-403e-4c5a-8a80-35839aae6393) |  ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-18 at 16 27 36](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/f2cb32bb-39be-4a4d-ad1e-b9710a9930c7)


### 기타

- `OptionCardButton` 수정
  - `OptionCardCell` 재사용 시 이전에 사용되던 색상 정보 나타나는 이유 존재
  - `prepareForReuse`에서 사용하기 위해 `setImage`, `setColor` 메소드를 수정하고 `showMoreInfoButton` 메소드를 구현했습니다
- `URColor` 모델의 `red`, `green`, `blue` 프로퍼티 타입 수정
  - 기존 타입은 `Int8`이라 사용 가능한 정수 범위가 -128~127 -> `UInt8`로 수정하여 0~255로 초기화 가능

## 📌 하고싶은 말

ㅎㅎ 어제 밤에 쓰려다가 기절했어요 ...
드디어 금요일이네요 ~~ 주말에도 화이팅입니다 ! 몸 챙기면서 하십쇼

그리고 해당 부분 구현하다가 뷰 구조가 헷갈려서 그려봤습니다 ! 노션에도 있으니 헷갈릴 때 참고하세욥


<img width="400" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/95aaa08b-dbae-4189-b958-dc001569ac0d">
