### PR TITLE
[BE] 사용자 정보에 따라 추천 견적 반환 API 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/guide/controller/TagController.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/controller/TagController.java
@@ -2,14 +2,15 @@ package com.example.backend.domain.guide.controller;
 
 import com.example.backend.domain.global.dto.ResponseDto;
 import com.example.backend.domain.global.model.enums.ResultCode;
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.guide.dto.FinalEstimateResponse;
 import com.example.backend.domain.guide.dto.TagListResponse;
+import com.example.backend.domain.guide.service.JYCarRecommendationService;
 import com.example.backend.domain.guide.service.TagService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -18,11 +19,21 @@ import java.util.List;
 @RequestMapping("/api/v1/guide")
 public class TagController {
     private final TagService tagService;
+    private final JYCarRecommendationService jyCarRecommendationService;
 
     @GetMapping("/tag")
     public ResponseEntity<ResponseDto<List<TagListResponse>>> returnAllTagWithCategory() {
         List<TagListResponse> results = tagService.returnAllTag();
         ResponseDto<List<TagListResponse>> body = ResponseDto.of(results, ResultCode.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(body);
+    }
+
+    @PostMapping("")
+    public ResponseEntity<ResponseDto<FinalEstimateResponse>> returnGuideOption(
+            @RequestBody EstimateRequest request
+    ) {
+        FinalEstimateResponse result = jyCarRecommendationService.estimate(request);
+        ResponseDto<FinalEstimateResponse> body = ResponseDto.of(result, ResultCode.SUCCESS);
         return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/dto/EstimateRequest.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/dto/EstimateRequest.java
@@ -3,6 +3,10 @@ package com.example.backend.domain.guide.dto;
 import com.example.backend.domain.sale.entity.enums.Gender;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @Getter
 public class EstimateRequest {
     private int age;
@@ -10,4 +14,8 @@ public class EstimateRequest {
     private long tag1;
     private long tag2;
     private long tag3;
+
+    public List<Long> getTagList() {
+        return Arrays.asList(tag1, tag2, tag3);
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/dto/FinalEstimateResponse.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/dto/FinalEstimateResponse.java
@@ -1,5 +1,6 @@
 package com.example.backend.domain.guide.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -13,4 +14,15 @@ public class FinalEstimateResponse {
     private long interiorColorId;
     private long wheelId;
     private List<Long> additionalOptionId;
+
+    @Builder
+    public FinalEstimateResponse(long powertrainId, long bodytypeId, long drivingSystemId, long exteriorColorId, long interiorColorId, long wheelId, List<Long> additionalOptionId) {
+        this.powertrainId = powertrainId;
+        this.bodytypeId = bodytypeId;
+        this.drivingSystemId = drivingSystemId;
+        this.exteriorColorId = exteriorColorId;
+        this.interiorColorId = interiorColorId;
+        this.wheelId = wheelId;
+        this.additionalOptionId = additionalOptionId;
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
@@ -1,0 +1,41 @@
+package com.example.backend.domain.guide.repository;
+
+import com.example.backend.domain.sale.entity.enums.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TagOptionRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public List<Long> findOptionIdByTagId(String category, Long tagId) {
+        String query = String.format("SELECT %s_id FROM TAG_%s WHERE tag_id = %d", category, category.toUpperCase(), tagId);
+        return jdbcTemplate.query(query, getRowMapperOfField(category));
+    }
+
+    private RowMapper<Long> getRowMapperOfField(String field) {
+        return new RowMapper<Long>() {
+            @Override
+            public Long mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return rs.getLong(field + "_id");
+            }
+        };
+    }
+
+    public List<Long> findOptionIdByGenderAge(String category, Gender gender, int age) {
+        String category_id = category + "_id";
+        String query = "SELECT m." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
+                "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +
+                "s.gender = \'" + gender.name() + "\' AND "+ age + "<= s.age <" + (age+10) +
+                " GROUP BY m." + category_id + " ORDER BY select_count DESC LIMIT 1";
+
+        return jdbcTemplate.query(query, getRowMapperOfField(category));
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
@@ -39,7 +39,7 @@ public class TagOptionRepository {
         return jdbcTemplate.query(query, getRowMapperOfField(category));
     }
 
-    public List<Long> findColorIdByGenderAge(String category, Gender gender, int age) {
+    public List<Long> findColorOrWheelIdByGenderAge(String category, Gender gender, int age) {
         String category_id = category + "_id";
         String query = "SELECT s." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
                 "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +

--- a/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
@@ -38,4 +38,14 @@ public class TagOptionRepository {
 
         return jdbcTemplate.query(query, getRowMapperOfField(category));
     }
+
+    public List<Long> findColorIdByGenderAge(String category, Gender gender, int age) {
+        String category_id = category + "_id";
+        String query = "SELECT s." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
+                "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +
+                "s.gender = \'" + gender.name() + "\' AND "+ age + "<= s.age <" + (age+10) +
+                " GROUP BY s." + category_id + " ORDER BY select_count DESC LIMIT 1";
+
+        return jdbcTemplate.query(query, getRowMapperOfField(category));
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
@@ -1,0 +1,57 @@
+package com.example.backend.domain.guide.service;
+
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.guide.dto.FinalEstimateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JYCarRecommendationService implements CarRecommendationService {
+    private final JYOptionRecommendationHandler optionRecommendationHandler;
+
+    @Override
+    public FinalEstimateResponse estimate(EstimateRequest estimate) {
+//        Field[] fields = FinalEstimateResponse.class.getDeclaredFields();
+//        for (Field field : fields)
+        return FinalEstimateResponse.builder()
+                .powertrainId(getRecommendOptionList("powertrain", estimate).get(0))
+                .bodytypeId(getRecommendOptionList("bodytype", estimate).get(0))
+                .drivingSystemId(getRecommendOptionList("driving_system", estimate).get(0))
+                .exteriorColorId(getRecommendOptionList("exterior_color", estimate).get(0))
+                .interiorColorId(getRecommendOptionList("interior_color", estimate).get(0))
+                .wheelId(getRecommendOptionList("wheel", estimate).get(0))
+                .additionalOptionId(getRecommendOptionList("additional_option", estimate))
+                .build();
+    }
+
+    private List<Long> getRecommendOptionList(String field, EstimateRequest estimate) {
+        if (field.equals("wheel"))
+            return getRecommendWheelList(field, estimate);
+        if (field.contains("color"))
+            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+        return getRecommendBaseOptionList(field, estimate);
+    }
+
+    private List<Long> getRecommendWheelList(String field, EstimateRequest estimate) {
+        List<Long> tagList = estimate.getTagList();
+        if(tagList.contains(1L) || tagList.contains(10L))
+            return List.of(4L);
+        if(tagList.contains(5L))
+            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+        return List.of(1L);
+    }
+
+
+    private List<Long> getRecommendBaseOptionList(String field, EstimateRequest estimate) {
+        List<Long> optionList = optionRecommendationHandler.findByTag(field, estimate.getTagList());
+        if (optionList.size() == 0 && !field.contains("option"))
+            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+        return optionList;
+    }
+
+}

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
@@ -33,7 +33,7 @@ public class JYCarRecommendationService implements CarRecommendationService {
         if (field.equals("wheel"))
             return getRecommendWheelList(field, estimate);
         if (field.contains("color"))
-            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+            return optionRecommendationHandler.findTopSalesCountOfColor(field, estimate.getGender(), estimate.getAge());
         return getRecommendBaseOptionList(field, estimate);
     }
 

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
@@ -5,8 +5,6 @@ import com.example.backend.domain.guide.dto.FinalEstimateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -33,7 +31,7 @@ public class JYCarRecommendationService implements CarRecommendationService {
         if (field.equals("wheel"))
             return getRecommendWheelList(field, estimate);
         if (field.contains("color"))
-            return optionRecommendationHandler.findTopSalesCountOfColor(field, estimate.getGender(), estimate.getAge());
+            return optionRecommendationHandler.findTopSalesCountOfColorAndWheel(field, estimate.getGender(), estimate.getAge());
         return getRecommendBaseOptionList(field, estimate);
     }
 
@@ -42,7 +40,7 @@ public class JYCarRecommendationService implements CarRecommendationService {
         if(tagList.contains(1L) || tagList.contains(10L))
             return List.of(4L);
         if(tagList.contains(5L))
-            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+            return optionRecommendationHandler.findTopSalesCountOfColorAndWheel(field, estimate.getGender(), estimate.getAge());
         return List.of(1L);
     }
 

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
@@ -1,0 +1,31 @@
+package com.example.backend.domain.guide.service;
+
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.guide.repository.TagOptionRepository;
+import com.example.backend.domain.sale.entity.enums.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JYOptionRecommendationHandler implements OptionRecommendationHandler {
+    private final TagOptionRepository tagOptionRepository;
+
+    @Override
+    public List<Long> findByTag(String category, List<Long> tagIds) {
+        for(Long tagId: tagIds) {
+            List<Long> optionList = tagOptionRepository.findOptionIdByTagId(category, tagId);
+            if(optionList.size() != 0)
+                return optionList;
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<Long> findTopSalesCount(String category, Gender gender, int age) {
+        return tagOptionRepository.findOptionIdByGenderAge(category, gender, age);
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
@@ -1,6 +1,5 @@
 package com.example.backend.domain.guide.service;
 
-import com.example.backend.domain.guide.dto.EstimateRequest;
 import com.example.backend.domain.guide.repository.TagOptionRepository;
 import com.example.backend.domain.sale.entity.enums.Gender;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +28,7 @@ public class JYOptionRecommendationHandler implements OptionRecommendationHandle
         return tagOptionRepository.findOptionIdByGenderAge(category, gender, age);
     }
 
-    public List<Long> findTopSalesCountOfColor(String category, Gender gender, int age) {
-        return tagOptionRepository.findColorIdByGenderAge(category, gender, age);
+    public List<Long> findTopSalesCountOfColorAndWheel(String category, Gender gender, int age) {
+        return tagOptionRepository.findColorOrWheelIdByGenderAge(category, gender, age);
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
@@ -28,4 +28,8 @@ public class JYOptionRecommendationHandler implements OptionRecommendationHandle
     public List<Long> findTopSalesCount(String category, Gender gender, int age) {
         return tagOptionRepository.findOptionIdByGenderAge(category, gender, age);
     }
+
+    public List<Long> findTopSalesCountOfColor(String category, Gender gender, int age) {
+        return tagOptionRepository.findColorIdByGenderAge(category, gender, age);
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandler.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 public interface OptionRecommendationHandler {
     // 태그 3순위까지 순차적으로 조회한다.
-    List<Long> findByTag(String category, String tag);
+    List<Long> findByTag(String category, List<Long> tagId);
 
     // 판매량이 가장 높은 옵션을 조회한다.
-    List<Long> findTopSalesCount(Gender gender, int age);
+    List<Long> findTopSalesCount(String category, Gender gender, int age);
 }


### PR DESCRIPTION
## 🔖 관련 이슈
- #123

## 📝 구현 사항
- 사용자의 정보를 age, gender, tag1, tag2, tag3의 필드를 통해 받아온다.
- 사용자가 선택한 태그나 성별, 연령에 따라 추천 옵션을 반환한다.
- 추천 기준(로직)은 기획서를 따른다.

## 📌 하고싶은 말
- post로 구현했고 바디로 다 받아요.
- tag 다 id로 받게 구현해뒀는데, 태그 목록 처음에 반환 드리니까 괜찮지 않을까여
- Jdbc Template 사용했습니다.... 너무 통일감이 없나여...
- 리팩토링이 필요할 것 같습니다. 지금 파일 이름에 JY 붙여놓아서 여기에 먼저 머지하고 리팩토링 후에 PR 올릴게여 
