### PR TITLE
[BE] 추천 옵션의 사용자 선택 태그 판매량을 반환하는 API 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/guide/controller/TagController.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/controller/TagController.java
@@ -2,14 +2,15 @@ package com.example.backend.domain.guide.controller;
 
 import com.example.backend.domain.global.dto.ResponseDto;
 import com.example.backend.domain.global.model.enums.ResultCode;
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.guide.dto.FinalEstimateResponse;
 import com.example.backend.domain.guide.dto.TagListResponse;
+import com.example.backend.domain.guide.service.JYCarRecommendationService;
 import com.example.backend.domain.guide.service.TagService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -18,11 +19,21 @@ import java.util.List;
 @RequestMapping("/api/v1/guide")
 public class TagController {
     private final TagService tagService;
+    private final JYCarRecommendationService jyCarRecommendationService;
 
     @GetMapping("/tag")
     public ResponseEntity<ResponseDto<List<TagListResponse>>> returnAllTagWithCategory() {
         List<TagListResponse> results = tagService.returnAllTag();
         ResponseDto<List<TagListResponse>> body = ResponseDto.of(results, ResultCode.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(body);
+    }
+
+    @PostMapping("")
+    public ResponseEntity<ResponseDto<FinalEstimateResponse>> returnGuideOption(
+            @RequestBody EstimateRequest request
+    ) {
+        FinalEstimateResponse result = jyCarRecommendationService.estimate(request);
+        ResponseDto<FinalEstimateResponse> body = ResponseDto.of(result, ResultCode.SUCCESS);
         return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/dto/EstimateRequest.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/dto/EstimateRequest.java
@@ -3,6 +3,10 @@ package com.example.backend.domain.guide.dto;
 import com.example.backend.domain.sale.entity.enums.Gender;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @Getter
 public class EstimateRequest {
     private int age;
@@ -10,4 +14,8 @@ public class EstimateRequest {
     private long tag1;
     private long tag2;
     private long tag3;
+
+    public List<Long> getTagList() {
+        return Arrays.asList(tag1, tag2, tag3);
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/dto/FinalEstimateResponse.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/dto/FinalEstimateResponse.java
@@ -1,5 +1,6 @@
 package com.example.backend.domain.guide.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -13,4 +14,15 @@ public class FinalEstimateResponse {
     private long interiorColorId;
     private long wheelId;
     private List<Long> additionalOptionId;
+
+    @Builder
+    public FinalEstimateResponse(long powertrainId, long bodytypeId, long drivingSystemId, long exteriorColorId, long interiorColorId, long wheelId, List<Long> additionalOptionId) {
+        this.powertrainId = powertrainId;
+        this.bodytypeId = bodytypeId;
+        this.drivingSystemId = drivingSystemId;
+        this.exteriorColorId = exteriorColorId;
+        this.interiorColorId = interiorColorId;
+        this.wheelId = wheelId;
+        this.additionalOptionId = additionalOptionId;
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
@@ -1,0 +1,41 @@
+package com.example.backend.domain.guide.repository;
+
+import com.example.backend.domain.sale.entity.enums.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TagOptionRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public List<Long> findOptionIdByTagId(String category, Long tagId) {
+        String query = String.format("SELECT %s_id FROM TAG_%s WHERE tag_id = %d", category, category.toUpperCase(), tagId);
+        return jdbcTemplate.query(query, getRowMapperOfField(category));
+    }
+
+    private RowMapper<Long> getRowMapperOfField(String field) {
+        return new RowMapper<Long>() {
+            @Override
+            public Long mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return rs.getLong(field + "_id");
+            }
+        };
+    }
+
+    public List<Long> findOptionIdByGenderAge(String category, Gender gender, int age) {
+        String category_id = category + "_id";
+        String query = "SELECT m." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
+                "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +
+                "s.gender = \'" + gender.name() + "\' AND "+ age + "<= s.age <" + (age+10) +
+                " GROUP BY m." + category_id + " ORDER BY select_count DESC LIMIT 1";
+
+        return jdbcTemplate.query(query, getRowMapperOfField(category));
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
@@ -32,8 +32,8 @@ public class TagOptionRepository {
     public List<Long> findOptionIdByGenderAge(String category, Gender gender, int age) {
         String category_id = category + "_id";
         String query = "SELECT m." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
-                "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +
-                "s.gender = \'" + gender.name() + "\' AND "+ age + "<= s.age <" + (age+10) +
+                "JOIN (SELECT id, " + category_id + " FROM MODEL WHERE trim_id = 1) AS m on s.model_id = m.id\n" +
+                "WHERE " + gender.getQueryString() + age + "<= s.age <" + (age+10) +
                 " GROUP BY m." + category_id + " ORDER BY select_count DESC LIMIT 1";
 
         return jdbcTemplate.query(query, getRowMapperOfField(category));
@@ -42,8 +42,8 @@ public class TagOptionRepository {
     public List<Long> findColorOrWheelIdByGenderAge(String category, Gender gender, int age) {
         String category_id = category + "_id";
         String query = "SELECT s." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
-                "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +
-                "s.gender = \'" + gender.name() + "\' AND "+ age + "<= s.age <" + (age+10) +
+                "JOIN (SELECT id FROM MODEL WHERE trim_id = 1) AS m on s.model_id = m.id\n" +
+                "WHERE " + gender.getQueryString() + age + "<= s.age <" + (age+10) +
                 " GROUP BY s." + category_id + " ORDER BY select_count DESC LIMIT 1";
 
         return jdbcTemplate.query(query, getRowMapperOfField(category));

--- a/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
@@ -39,7 +39,7 @@ public class TagOptionRepository {
         return jdbcTemplate.query(query, getRowMapperOfField(category));
     }
 
-    public List<Long> findColorIdByGenderAge(String category, Gender gender, int age) {
+    public List<Long> findColorOrWheelIdByGenderAge(String category, Gender gender, int age) {
         String category_id = category + "_id";
         String query = "SELECT s." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
                 "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +

--- a/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/repository/TagOptionRepository.java
@@ -38,4 +38,14 @@ public class TagOptionRepository {
 
         return jdbcTemplate.query(query, getRowMapperOfField(category));
     }
+
+    public List<Long> findColorIdByGenderAge(String category, Gender gender, int age) {
+        String category_id = category + "_id";
+        String query = "SELECT s." + category_id + ", COUNT(*) as select_count FROM SALES s\n" +
+                "JOIN MODEL m on s.model_id = m.id WHERE m.trim_id = 1 AND\n" +
+                "s.gender = \'" + gender.name() + "\' AND "+ age + "<= s.age <" + (age+10) +
+                " GROUP BY s." + category_id + " ORDER BY select_count DESC LIMIT 1";
+
+        return jdbcTemplate.query(query, getRowMapperOfField(category));
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
@@ -1,0 +1,57 @@
+package com.example.backend.domain.guide.service;
+
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.guide.dto.FinalEstimateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JYCarRecommendationService implements CarRecommendationService {
+    private final JYOptionRecommendationHandler optionRecommendationHandler;
+
+    @Override
+    public FinalEstimateResponse estimate(EstimateRequest estimate) {
+//        Field[] fields = FinalEstimateResponse.class.getDeclaredFields();
+//        for (Field field : fields)
+        return FinalEstimateResponse.builder()
+                .powertrainId(getRecommendOptionList("powertrain", estimate).get(0))
+                .bodytypeId(getRecommendOptionList("bodytype", estimate).get(0))
+                .drivingSystemId(getRecommendOptionList("driving_system", estimate).get(0))
+                .exteriorColorId(getRecommendOptionList("exterior_color", estimate).get(0))
+                .interiorColorId(getRecommendOptionList("interior_color", estimate).get(0))
+                .wheelId(getRecommendOptionList("wheel", estimate).get(0))
+                .additionalOptionId(getRecommendOptionList("additional_option", estimate))
+                .build();
+    }
+
+    private List<Long> getRecommendOptionList(String field, EstimateRequest estimate) {
+        if (field.equals("wheel"))
+            return getRecommendWheelList(field, estimate);
+        if (field.contains("color"))
+            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+        return getRecommendBaseOptionList(field, estimate);
+    }
+
+    private List<Long> getRecommendWheelList(String field, EstimateRequest estimate) {
+        List<Long> tagList = estimate.getTagList();
+        if(tagList.contains(1L) || tagList.contains(10L))
+            return List.of(4L);
+        if(tagList.contains(5L))
+            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+        return List.of(1L);
+    }
+
+
+    private List<Long> getRecommendBaseOptionList(String field, EstimateRequest estimate) {
+        List<Long> optionList = optionRecommendationHandler.findByTag(field, estimate.getTagList());
+        if (optionList.size() == 0 && !field.contains("option"))
+            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+        return optionList;
+    }
+
+}

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
@@ -33,7 +33,7 @@ public class JYCarRecommendationService implements CarRecommendationService {
         if (field.equals("wheel"))
             return getRecommendWheelList(field, estimate);
         if (field.contains("color"))
-            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+            return optionRecommendationHandler.findTopSalesCountOfColor(field, estimate.getGender(), estimate.getAge());
         return getRecommendBaseOptionList(field, estimate);
     }
 

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYCarRecommendationService.java
@@ -5,8 +5,6 @@ import com.example.backend.domain.guide.dto.FinalEstimateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -33,7 +31,7 @@ public class JYCarRecommendationService implements CarRecommendationService {
         if (field.equals("wheel"))
             return getRecommendWheelList(field, estimate);
         if (field.contains("color"))
-            return optionRecommendationHandler.findTopSalesCountOfColor(field, estimate.getGender(), estimate.getAge());
+            return optionRecommendationHandler.findTopSalesCountOfColorAndWheel(field, estimate.getGender(), estimate.getAge());
         return getRecommendBaseOptionList(field, estimate);
     }
 
@@ -42,7 +40,7 @@ public class JYCarRecommendationService implements CarRecommendationService {
         if(tagList.contains(1L) || tagList.contains(10L))
             return List.of(4L);
         if(tagList.contains(5L))
-            return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
+            return optionRecommendationHandler.findTopSalesCountOfColorAndWheel(field, estimate.getGender(), estimate.getAge());
         return List.of(1L);
     }
 

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
@@ -1,0 +1,31 @@
+package com.example.backend.domain.guide.service;
+
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.guide.repository.TagOptionRepository;
+import com.example.backend.domain.sale.entity.enums.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JYOptionRecommendationHandler implements OptionRecommendationHandler {
+    private final TagOptionRepository tagOptionRepository;
+
+    @Override
+    public List<Long> findByTag(String category, List<Long> tagIds) {
+        for(Long tagId: tagIds) {
+            List<Long> optionList = tagOptionRepository.findOptionIdByTagId(category, tagId);
+            if(optionList.size() != 0)
+                return optionList;
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<Long> findTopSalesCount(String category, Gender gender, int age) {
+        return tagOptionRepository.findOptionIdByGenderAge(category, gender, age);
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
@@ -1,6 +1,5 @@
 package com.example.backend.domain.guide.service;
 
-import com.example.backend.domain.guide.dto.EstimateRequest;
 import com.example.backend.domain.guide.repository.TagOptionRepository;
 import com.example.backend.domain.sale.entity.enums.Gender;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +28,7 @@ public class JYOptionRecommendationHandler implements OptionRecommendationHandle
         return tagOptionRepository.findOptionIdByGenderAge(category, gender, age);
     }
 
-    public List<Long> findTopSalesCountOfColor(String category, Gender gender, int age) {
-        return tagOptionRepository.findColorIdByGenderAge(category, gender, age);
+    public List<Long> findTopSalesCountOfColorAndWheel(String category, Gender gender, int age) {
+        return tagOptionRepository.findColorOrWheelIdByGenderAge(category, gender, age);
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/JYOptionRecommendationHandler.java
@@ -28,4 +28,8 @@ public class JYOptionRecommendationHandler implements OptionRecommendationHandle
     public List<Long> findTopSalesCount(String category, Gender gender, int age) {
         return tagOptionRepository.findOptionIdByGenderAge(category, gender, age);
     }
+
+    public List<Long> findTopSalesCountOfColor(String category, Gender gender, int age) {
+        return tagOptionRepository.findColorIdByGenderAge(category, gender, age);
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandler.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 public interface OptionRecommendationHandler {
     // 태그 3순위까지 순차적으로 조회한다.
-    List<Long> findByTag(String category, String tag);
+    List<Long> findByTag(String category, List<Long> tagId);
 
     // 판매량이 가장 높은 옵션을 조회한다.
-    List<Long> findTopSalesCount(Gender gender, int age);
+    List<Long> findTopSalesCount(String category, Gender gender, int age);
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -3,7 +3,9 @@ package com.example.backend.domain.sale.controller;
 import com.example.backend.domain.global.dto.ResponseDto;
 import com.example.backend.domain.global.model.enums.ResultCode;
 import com.example.backend.domain.sale.dto.SalesSummaryResponse;
+import com.example.backend.domain.sale.dto.TagRatioRequest;
 import com.example.backend.domain.sale.service.SelfModeServiceFactory;
+import com.example.backend.domain.sale.service.TagSelectionRatioService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequestMapping("/api/v1/sale")
 public class SaleRatioController {
     private final SelfModeServiceFactory selfModeServiceFactory;
+    private final TagSelectionRatioService tagSelectionRatioService;
 
     @GetMapping("{target:exterior-color|interior-color|wheel}/select")
     public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> returnSelectionRatioInSelfMode(
@@ -38,6 +41,14 @@ public class SaleRatioController {
             @RequestParam("category") String category
     ) {
         List<SalesSummaryResponse> result = selfModeServiceFactory.getOptionSelectionRatio(category);
+        return mapToOKResponse(result);
+    }
+
+    @PostMapping("/tag")
+    public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> returnTagSelectionRatio(
+            @RequestBody TagRatioRequest request
+    ) {
+        List<SalesSummaryResponse> result = tagSelectionRatioService.getSelectionRatio(request);
         return mapToOKResponse(result);
     }
 

--- a/backend/src/main/java/com/example/backend/domain/sale/dto/TagRatioRequest.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/dto/TagRatioRequest.java
@@ -1,0 +1,18 @@
+package com.example.backend.domain.sale.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class TagRatioRequest {
+    private String category;
+    private Long optionId;
+    private Long tag1;
+    private Long tag2;
+    private Long tag3;
+
+    public List<Long> getTagList() {
+        return List.of(tag1, tag2, tag3);
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/sale/entity/enums/Gender.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/entity/enums/Gender.java
@@ -10,4 +10,10 @@ public enum Gender {
     Gender(String korean) {
         this.korean = korean;
     }
+
+    public String getQueryString() {
+        if(this == NONE)
+            return " ";
+        return "gender = \'" + this.name() + "\' AND ";
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/TagRatioTemplateRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/TagRatioTemplateRepository.java
@@ -1,0 +1,61 @@
+package com.example.backend.domain.sale.repository;
+
+import com.example.backend.domain.sale.entity.SalesSummary;
+import com.example.backend.domain.sale.mapper.SelectionRatioRowMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TagRatioTemplateRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public List<Long> findRelatedTagListWithOption(Long tagId, String category, Long optionId) {
+        String query = String.format("SELECT tag_id FROM TAG_%s WHERE %s_id = %d AND tag_id = %d",
+                                            category.toUpperCase(), category, optionId, tagId);
+        return jdbcTemplate.query(query, new RowMapper<Long>() {
+            @Override
+            public Long mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return rs.getLong("tag_id");
+            }
+        });
+    }
+
+    public List<SalesSummary> findBaseOptionCount(Long tagId, String category, Long optionId) {
+        String category_id = category + "_id";
+        String query = "SELECT * FROM (SELECT m." + category_id + " AS id, COUNT(*) AS select_count FROM SALES s \n" +
+                "JOIN MODEL m ON s.model_id = m.id \n" +
+                " WHERE (s.tag1 = " + tagId + " OR s.tag2 = " + tagId + " OR s.tag3 = " + tagId + " )\n" +
+                "GROUP BY m." + category_id + " WITH ROLLUP) AS count_table \n" +
+                "WHERE id = " + optionId + " OR id IS NULL";
+
+        return jdbcTemplate.query(query, new SelectionRatioRowMapper());
+    }
+
+    public List<SalesSummary> findColorWheelOptionCount(Long tagId, String category, Long optionId) {
+        String category_id = category + "_id";
+        String query = "SELECT * FROM (SELECT " + category_id + " AS id, COUNT(*) AS select_count FROM SALES \n" +
+                "WHERE (tag1 = " + tagId + " OR tag2 = " + tagId + " OR tag3 = " + tagId + " )\n" +
+                "GROUP BY " + category_id + " WITH ROLLUP) AS count_table \n" +
+                "WHERE id = " + optionId + " OR id IS NULL";
+
+        return jdbcTemplate.query(query, new SelectionRatioRowMapper());
+    }
+
+    public List<SalesSummary> findAdditionalOptionCount(Long tagId, String category, Long optionId) {
+        String category_id = category + "_id";
+        String query = "SELECT * FROM (SELECT so." + category_id + " AS id, COUNT(*) AS select_count FROM SALES s \n" +
+                        "JOIN SALES_OPTIONS so ON s.id = so.sales_id \n" +
+                        " WHERE (s.tag1 = " + tagId + " OR s.tag2 = " + tagId + " OR s.tag3 = " + tagId + " )\n" +
+                        "GROUP BY so." + category_id + " WITH ROLLUP) AS count_table \n" +
+                        "WHERE id = " + optionId + " OR id IS NULL";
+
+        return jdbcTemplate.query(query, new SelectionRatioRowMapper());
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/sale/service/TagSelectionRatioService.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/TagSelectionRatioService.java
@@ -1,0 +1,49 @@
+package com.example.backend.domain.sale.service;
+
+import com.example.backend.domain.sale.dto.SalesSummaryResponse;
+import com.example.backend.domain.sale.dto.TagRatioRequest;
+import com.example.backend.domain.sale.entity.SalesSummary;
+import com.example.backend.domain.sale.repository.TagRatioTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagSelectionRatioService {
+    private final TagRatioTemplateRepository tagRatioTemplateRepository;
+
+    public List<SalesSummaryResponse> getSelectionRatio(TagRatioRequest request) {
+        List<Long> tagList = getRelatedTagList(request.getTagList(), request.getCategory(), request.getOptionId());
+        List<SalesSummaryResponse> result = new ArrayList<>();
+        for(Long tagId: tagList) {
+            List<SalesSummary> optionCount = getOptionSelectionRatioWithTag(tagId, request.getCategory(), request.getOptionId());
+            int ratio = calculateRatio(optionCount);
+            result.add(new SalesSummaryResponse(tagId, ratio));
+        }
+        return result;
+    }
+
+    private int calculateRatio(List<SalesSummary> optionCount) {
+        return (int)(100 * optionCount.get(0).getSelectionCount() / optionCount.get(1).getSelectionCount());
+    }
+
+    private List<SalesSummary> getOptionSelectionRatioWithTag(Long tagId, String category, Long optionId) {
+        if(category.contains("option"))
+            return tagRatioTemplateRepository.findAdditionalOptionCount(tagId, category, optionId);
+        if(category.contains("color") || category.contains("wheel"))
+            return tagRatioTemplateRepository.findColorWheelOptionCount(tagId, category, optionId);
+        return tagRatioTemplateRepository.findBaseOptionCount(tagId, category, optionId);
+    }
+
+
+    private List<Long> getRelatedTagList(List<Long> tagList, String category, Long optionId) {
+        List<Long> result = new ArrayList<>();
+        for(Long tagId: tagList) {
+            result.addAll(tagRatioTemplateRepository.findRelatedTagListWithOption(tagId, category, optionId));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## 🔖 관련 이슈
- #122

## 📝 구현 사항
- 사용자 태그와 옵션의 카테고리, 아이디를 입력 받아서 태그의 선택률을 알려줍니다.
- 먼저 사용자가 선택한 태그와 옵션이 서로 관계가 있는지 확인합니다.
- 관계가 있을 경우 판매 데이터 중 해당 태그를 선택한 사용자의 수와 해당 태그를 선택하고 해당 옵션을 선택한 사용자의 수를 구하여 비율을 계산하여 반환합니다.
- 3개의 태그에 대해 모두 진행하여 관련 태그 모두에 관한 비율을 반환합니다.

## 📌 하고싶은 말
- 앞선 PR과 동일합니다..! guide_mode 브랜치에 합치고 리팩토링 후에 develop-be에 합치겠습니다.
- sale과 로직이 비슷해서 salesummary 등을 사용했는데 뭔가 리네이밍이 필요할 것 같습니다.
- 비슷한 로직인데 전략 패턴이라기 보다 if 문을 이용한 것 같아서 로직 보시고 뭔가 마음에 안들면 리팩토링 해요....같이.....
