### PR TITLE
[BE] 태그 선택률이 80% 이상 비슷한 사용자의 각 옵션 선택률 API

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/global/model/enums/ResultCode.java
+++ b/backend/src/main/java/com/example/backend/domain/global/model/enums/ResultCode.java
@@ -19,7 +19,10 @@ public enum ResultCode {
     END_PAGE(4103, HttpStatus.ACCEPTED, "마지막 페이지입니다!"),
     SALES_NOT_FOUND(4104, HttpStatus.BAD_REQUEST, "판매 정보가 없습니다."),
 
-    ILLEGAL_ARGUMENT(10001, HttpStatus.BAD_REQUEST, "해당 요청을 처리할 수 없습니다.");
+    FAIL_TO_READ_SQL_FILE(5000, HttpStatus.INTERNAL_SERVER_ERROR , "SQL 파일을 읽는 데 실패했습니다." ),
+
+    ILLEGAL_ARGUMENT(10001, HttpStatus.INTERNAL_SERVER_ERROR, "해당 요청을 처리할 수 없습니다.")
+    ;
 
     private final int code;
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/com/example/backend/domain/global/utils/StringUtils.java
+++ b/backend/src/main/java/com/example/backend/domain/global/utils/StringUtils.java
@@ -1,5 +1,12 @@
 package com.example.backend.domain.global.utils;
 
+import com.example.backend.domain.global.exception.RestApiException;
+import com.example.backend.domain.global.model.enums.ResultCode;
+import nonapi.io.github.classgraph.fileslice.reader.ClassfileReader;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.*;
+
 public class StringUtils {
     public static final String DASH = "-";
     public static final String UNDER_BAR = "_";
@@ -9,5 +16,22 @@ public class StringUtils {
 
     public static String transUriToColumnId(String uri) {
         return uri.replace(DASH, UNDER_BAR) + "_id";
+    }
+
+    public static String readSQLFile(String filePath) {
+        ClassPathResource resource = new ClassPathResource(filePath);
+        StringBuilder stringBuilder = new StringBuilder();
+        String tmp;
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+            while ((tmp = br.readLine()) != null) {
+                stringBuilder.append(tmp).append("\n"); // 개행문자 추가
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RestApiException(ResultCode.FAIL_TO_READ_SQL_FILE);
+        }
+
+        return stringBuilder.toString();
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/guide/dto/EstimateRequest.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/dto/EstimateRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class EstimateRequest {
     private int age;
-    private Gender gender;
+    private String gender;
     private long tag1;
     private long tag2;
     private long tag3;

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -2,7 +2,9 @@ package com.example.backend.domain.sale.controller;
 
 import com.example.backend.domain.global.dto.ResponseDto;
 import com.example.backend.domain.global.model.enums.ResultCode;
+import com.example.backend.domain.guide.dto.EstimateRequest;
 import com.example.backend.domain.sale.dto.SalesSummaryResponse;
+import com.example.backend.domain.sale.service.SelectionRatioWithSimilarUsersService;
 import com.example.backend.domain.sale.service.SelfModeServiceFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequestMapping("/api/v1/sale")
 public class SaleRatioController {
     private final SelfModeServiceFactory selfModeServiceFactory;
+    private final SelectionRatioWithSimilarUsersService selectionRatioWithSimilarUsersService;
 
     @GetMapping("{target:exterior-color|interior-color|wheel}/select")
     public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> returnSelectionRatioInSelfMode(
@@ -41,8 +44,17 @@ public class SaleRatioController {
         return mapToOKResponse(result);
     }
 
-    private ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> mapToOKResponse(List<SalesSummaryResponse> result) {
-        ResponseDto<List<SalesSummaryResponse>> body = ResponseDto.of(result, ResultCode.SUCCESS);
+    @PostMapping("/{target}/tag")
+    public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> re(
+            @PathVariable("target") String target,
+            @RequestBody EstimateRequest estimateRequest
+    ) {
+        List<SalesSummaryResponse> result = selectionRatioWithSimilarUsersService.calculateSelectionRatioWithSimilarUsers(target, estimateRequest);
+        return mapToOKResponse(result);
+    }
+
+    private <T> ResponseEntity<ResponseDto<T>> mapToOKResponse(T t) {
+        ResponseDto<T> body = ResponseDto.of(t, ResultCode.SUCCESS);
         return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -44,7 +44,7 @@ public class SaleRatioController {
         return mapToOKResponse(result);
     }
 
-    @PostMapping("/{target:powertrain|bodytype|driving-system}/tag")
+    @PostMapping("/{target:powertrain|bodytype|driving-system|wheel}/tag")
     public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> returnOrderedCarComponentSalesRatio(
             @PathVariable("target") String target,
             @RequestBody EstimateRequest estimateRequest

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -62,6 +62,13 @@ public class SaleRatioController {
         return mapToOKResponse(result);
     }
 
+    @PostMapping("/additional-option/tag")
+    public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> returnOrderedColorSalesRatio(
+            @RequestBody EstimateRequest estimateRequest
+    ) {
+        List<SalesSummaryResponse> result = selectionRatioWithSimilarUsersService.calculateSelectionRatioWithAdditionalOption(estimateRequest);
+        return mapToOKResponse(result);
+    }
     private <T> ResponseEntity<ResponseDto<T>> mapToOKResponse(T t) {
         ResponseDto<T> body = ResponseDto.of(t, ResultCode.SUCCESS);
         return ResponseEntity.status(HttpStatus.OK).body(body);

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -45,11 +45,20 @@ public class SaleRatioController {
     }
 
     @PostMapping("/{target:powertrain|bodytype|driving-system}/tag")
-    public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> re(
+    public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> returnOrderedCarComponentSalesRatio(
             @PathVariable("target") String target,
             @RequestBody EstimateRequest estimateRequest
     ) {
         List<SalesSummaryResponse> result = selectionRatioWithSimilarUsersService.calculateSelectionRatioWithSimilarUsers(target, estimateRequest);
+        return mapToOKResponse(result);
+    }
+
+    @PostMapping("/{target:exterior-color|interior-color}/tag")
+    public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> returnOrderedColorSalesRatio(
+            @PathVariable("target") String target,
+            @RequestBody EstimateRequest estimateRequest
+    ) {
+        List<SalesSummaryResponse> result = selectionRatioWithSimilarUsersService.calculateSelectionRatioWitSameAgeAndGender(target, estimateRequest);
         return mapToOKResponse(result);
     }
 

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -44,7 +44,7 @@ public class SaleRatioController {
         return mapToOKResponse(result);
     }
 
-    @PostMapping("/{target}/tag")
+    @PostMapping("/{target:powertrain|bodytype|driving-system}/tag")
     public ResponseEntity<ResponseDto<List<SalesSummaryResponse>>> re(
             @PathVariable("target") String target,
             @RequestBody EstimateRequest estimateRequest

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
@@ -1,7 +1,6 @@
 package com.example.backend.domain.sale.repository;
 
 import com.example.backend.domain.guide.dto.EstimateRequest;
-import com.example.backend.domain.sale.entity.Sales;
 import com.example.backend.domain.sale.entity.SalesSummary;
 import com.example.backend.domain.sale.mapper.SelectionRatioRowMapper;
 import lombok.RequiredArgsConstructor;
@@ -60,14 +59,8 @@ public class SalesTemplateRepository {
         return namedTemplate.query(query, params, new SelectionRatioRowMapper());
 */
         String targetId = transUriToColumnId(target);
-        long tag1 = estimateRequest.getTag1();
-        long tag2 = estimateRequest.getTag2();
-        long tag3 = estimateRequest.getTag3();
-        int age = estimateRequest.getAge();
-        String gender = estimateRequest.getGender();
-
         String query = getQueryDependsOn(targetId)
-                + getWhereQuery(targetId, tag1, tag2, tag3, age, gender);
+                + getWhereQuery(targetId, estimateRequest);
         return jdbcTemplate.query(query, new SelectionRatioRowMapper());
     }
 
@@ -88,15 +81,20 @@ public class SalesTemplateRepository {
     }
 
     public List<SalesSummary> findSelectionRatioOfAdditionalOption(EstimateRequest estimateRequest) {
-        long tag1 = estimateRequest.getTag1();
-        long tag2 = estimateRequest.getTag2();
-        long tag3 = estimateRequest.getTag3();
-        int age = estimateRequest.getAge();
-        String gender = estimateRequest.getGender();
-
         String query = getWithQueryWithAdditionalOption(ADDITIONAL_OPTION_ID)
-                + getWhereQuery(ADDITIONAL_OPTION_ID, tag1, tag2, tag3, age, gender);
+                + getWhereQuery(ADDITIONAL_OPTION_ID, estimateRequest);
         return jdbcTemplate.query(query, new SelectionRatioRowMapper());
+    }
+
+    private String getWhereQuery(String targetId, EstimateRequest estimateRequest) {
+        return getWhereQuery(
+                targetId, 
+                estimateRequest.getTag1(),
+                estimateRequest.getTag2(),
+                estimateRequest.getTag3(),
+                estimateRequest.getAge(), 
+                estimateRequest.getGender()
+        );
     }
 
     private String getQueryDependsOn(String targetId) {

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
@@ -1,5 +1,6 @@
 package com.example.backend.domain.sale.repository;
 
+import com.example.backend.domain.guide.dto.EstimateRequest;
 import com.example.backend.domain.sale.entity.SalesSummary;
 import com.example.backend.domain.sale.mapper.SelectionRatioRowMapper;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+
+import static com.example.backend.domain.global.utils.StringUtils.transUriToColumnId;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,6 +36,84 @@ public class SalesTemplateRepository {
                 "FROM SALES s " +
                 "GROUP BY s." + columnId + " WITH ROLLUP";
 
+        return jdbcTemplate.query(query, new SelectionRatioRowMapper());
+    }
+
+    public List<SalesSummary> findSelectionRatioWithSimilarUsers(String target, EstimateRequest estimateRequest) {
+/*
+        String rowFile = readSQLFile("sql/selectCountWithSimilarUsers.sql");
+        String query = String.format(rowFile, transUriToColumnId(target));
+
+
+        NamedParameterJdbcTemplate namedTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("targetId", transUriToColumnId(target))
+                .addValue("age", estimateRequest.getAge())
+                .addValue("gender", estimateRequest.getGender())
+                .addValue("tag1", estimateRequest.getTag1())
+                .addValue("tag2", estimateRequest.getTag2())
+                .addValue("tag3", estimateRequest.getTag3());
+
+        return namedTemplate.query(query, params, new SelectionRatioRowMapper());
+*/
+        String targetId = transUriToColumnId(target);
+        long tag1 = estimateRequest.getTag1();
+        long tag2 = estimateRequest.getTag2();
+        long tag3 = estimateRequest.getTag3();
+        int age = estimateRequest.getAge();
+        String gender = estimateRequest.getGender();
+
+        String query = "with joined as (select m." + targetId + ", age, gender, tag1, tag2, tag3\n" +
+                "                from SALES s\n" +
+                "                         join MODEL m on s.model_id = m.id\n" +
+                "                where m.trim_id = 1\n" +
+                "                )\n" +
+                "\n" +
+                "select " + targetId + "       as id,\n" +
+                "       count(" + targetId + ") as select_count\n" +
+                "from joined\n" +
+                "WHERE (\n" +
+                "            (" + tag1 + ", " + tag2 + ", " + tag3 + ") in ((tag1, tag2, tag3),\n" +
+                "                                      (tag1, tag3, tag2),\n" +
+                "                                      (tag2, tag1, tag3),\n" +
+                "                                      (tag2, tag3, tag1),\n" +
+                "                                      (tag3, tag1, tag2),\n" +
+                "                                      (tag3, tag2, tag1)\n" +
+                "            )\n" +
+                "        and (\n" +
+                "                    (" + age + " <= age and age<= " + (age + 9) + " and gender != '" + gender + "')\n" +
+                "                    or ((" + (age - 1) + " <= age or age >= " + (age + 10) + ") and gender = '" + gender + "')\n" +
+                "                    or (" + age + " <= age and age <= " + (age + 9) + " and gender = '" + gender + "')\n" +
+                "                )\n" +
+                "    )\n" +
+                "   or (\n" +
+                "         " + age + " <= age  and age <= " + (age + 9) + "\n" +
+                "        and gender = '" + gender + "'\n" +
+                "        and (\n" +
+                "                            (" + tag1 + ", " + tag2 + ") in ((tag1, tag2), (tag1, tag3),\n" +
+                "                                               (tag2, tag1), (tag2, tag3),\n" +
+                "                                               (tag3, tag1), (tag3, tag2))\n" +
+                "                        or\n" +
+                "                            (" + tag2 + ", " + tag3 + ") in ((tag1, tag2), (tag1, tag3),\n" +
+                "                                               (tag2, tag1), (tag2, tag3),\n" +
+                "                                               (tag3, tag1), (tag3, tag2))\n" +
+                "                        or\n" +
+                "                            (" + tag1 + ", " + tag3 + ") in ((tag1, tag2), (tag1, tag3),\n" +
+                "                                               (tag2, tag1), (tag2, tag3),\n" +
+                "                                               (tag3, tag1), (tag3, tag2))\n" +
+                "                    )\n" +
+                "        and (" + tag1 + ", " + tag2 + ", " + tag3 + ") not in (\n" +
+                "                                          (tag1, tag2, tag3),\n" +
+                "                                          (tag1, tag3, tag2),\n" +
+                "                                          (tag2, tag1, tag3),\n" +
+                "                                          (tag2, tag3, tag1),\n" +
+                "                                          (tag3, tag1, tag2),\n" +
+                "                                          (tag3, tag2, tag1)\n" +
+                "        )\n" +
+                "    )\n" +
+                "group by " + targetId + "\n" +
+                "with rollup";
         return jdbcTemplate.query(query, new SelectionRatioRowMapper());
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
@@ -116,4 +116,24 @@ public class SalesTemplateRepository {
                 "with rollup";
         return jdbcTemplate.query(query, new SelectionRatioRowMapper());
     }
+
+    public List<SalesSummary> findSelectionRatioWithSameAgeAndGender(String target, EstimateRequest estimateRequest) {
+        String targetId = transUriToColumnId(target);
+        int age = estimateRequest.getAge();
+
+        String query = "with joined as (select " + targetId + ", age, gender\n" +
+                "                from SALES s\n" +
+                "                         join MODEL m on s.model_id = m.id\n" +
+                "                where m.trim_id = 1)\n" +
+                "\n" +
+                "select " + targetId + " as id,\n" +
+                "             count(" + targetId + ") as select_count \n" +
+                "      from joined\n" +
+                "      WHERE\n" +
+                "              (" + age + "<=age and age<=" + (age + 9) + " and gender = 'MALE')\n" +
+                "      group by " + targetId + "\n" +
+                "with rollup";
+
+        return jdbcTemplate.query(query, new SelectionRatioRowMapper());
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersService.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersService.java
@@ -1,0 +1,10 @@
+package com.example.backend.domain.sale.service;
+
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.sale.dto.SalesSummaryResponse;
+
+import java.util.List;
+
+public interface SelectionRatioWithSimilarUsersService {
+    List<SalesSummaryResponse> calculateSelectionRatioWithSimilarUsers(String target, EstimateRequest estimateRequest);
+}

--- a/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersService.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersService.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface SelectionRatioWithSimilarUsersService {
     List<SalesSummaryResponse> calculateSelectionRatioWithSimilarUsers(String target, EstimateRequest estimateRequest);
+
+    List<SalesSummaryResponse> calculateSelectionRatioWitSameAgeAndGender(String target, EstimateRequest estimateRequest);
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersService.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersService.java
@@ -9,4 +9,6 @@ public interface SelectionRatioWithSimilarUsersService {
     List<SalesSummaryResponse> calculateSelectionRatioWithSimilarUsers(String target, EstimateRequest estimateRequest);
 
     List<SalesSummaryResponse> calculateSelectionRatioWitSameAgeAndGender(String target, EstimateRequest estimateRequest);
+
+    List<SalesSummaryResponse> calculateSelectionRatioWithAdditionalOption(EstimateRequest estimateRequest);
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
@@ -16,11 +16,22 @@ import java.util.List;
 public class SelectionRatioWithSimilarUsersServiceImpl implements SelectionRatioWithSimilarUsersService {
     private final SalesTemplateRepository repository;
     private final SummaryMapper summaryMapper;
+
     @Override
     public List<SalesSummaryResponse> calculateSelectionRatioWithSimilarUsers(String target, EstimateRequest estimateRequest) {
         List<SalesSummary> summaries = repository.findSelectionRatioWithSimilarUsers(target, estimateRequest);
+        return getSortedSalesSummaryResponses(summaries);
+    }
+
+    @Override
+    public List<SalesSummaryResponse> calculateSelectionRatioWitSameAgeAndGender(String target, EstimateRequest estimateRequest) {
+        List<SalesSummary> summaries = repository.findSelectionRatioWithSameAgeAndGender(target, estimateRequest);
+        return getSortedSalesSummaryResponses(summaries);
+    }
+
+    private List<SalesSummaryResponse> getSortedSalesSummaryResponses(List<SalesSummary> summaries) {
         List<SalesSummaryResponse> result = summaryMapper.map(summaries);
-        Collections.sort(result, (o1, o2)-> o2.getSelectionRatio() - o1.getSelectionRatio());
+        Collections.sort(result, (o1, o2) -> o2.getSelectionRatio() - o1.getSelectionRatio());
         return result;
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
@@ -29,6 +29,12 @@ public class SelectionRatioWithSimilarUsersServiceImpl implements SelectionRatio
         return getSortedSalesSummaryResponses(summaries);
     }
 
+    @Override
+    public List<SalesSummaryResponse> calculateSelectionRatioWithAdditionalOption(EstimateRequest estimateRequest) {
+        List<SalesSummary> summaries = repository.findSelectionRatioOfAdditionalOption(estimateRequest);
+        return getSortedSalesSummaryResponses(summaries);
+    }
+
     private List<SalesSummaryResponse> getSortedSalesSummaryResponses(List<SalesSummary> summaries) {
         List<SalesSummaryResponse> result = summaryMapper.map(summaries);
         Collections.sort(result, (o1, o2) -> o2.getSelectionRatio() - o1.getSelectionRatio());

--- a/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
@@ -1,0 +1,26 @@
+package com.example.backend.domain.sale.service;
+
+import com.example.backend.domain.guide.dto.EstimateRequest;
+import com.example.backend.domain.sale.dto.SalesSummaryResponse;
+import com.example.backend.domain.sale.entity.SalesSummary;
+import com.example.backend.domain.sale.mapper.SummaryMapper;
+import com.example.backend.domain.sale.repository.SalesTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SelectionRatioWithSimilarUsersServiceImpl implements SelectionRatioWithSimilarUsersService {
+    private final SalesTemplateRepository repository;
+    private final SummaryMapper summaryMapper;
+    @Override
+    public List<SalesSummaryResponse> calculateSelectionRatioWithSimilarUsers(String target, EstimateRequest estimateRequest) {
+        List<SalesSummary> summaries = repository.findSelectionRatioWithSimilarUsers(target, estimateRequest);
+        List<SalesSummaryResponse> result = summaryMapper.map(summaries);
+        Collections.sort(result, (o1, o2)-> o2.getSelectionRatio() - o1.getSelectionRatio());
+        return result;
+    }
+}

--- a/backend/src/main/resources/sql/selectCountWithSimilarUsers.sql
+++ b/backend/src/main/resources/sql/selectCountWithSimilarUsers.sql
@@ -1,0 +1,50 @@
+with joined as (select {0}, age, gender, tag1, tag2, tag3
+                from SALES s
+                         join MODEL m on s.model_id = m.id
+                where m.trim_id = 1
+                )
+
+select {0}       as id,
+       count({0}) as select_count
+from joined
+WHERE (
+            (:tag1, :tag2, :tag3) in ((tag1, tag2, tag3),
+                                      (tag1, tag3, tag2),
+                                      (tag2, tag1, tag3),
+                                      (tag2, tag3, tag1),
+                                      (tag3, tag1, tag2),
+                                      (tag3, tag2, tag1)
+            )
+        and (
+                    (:age <= age <= :age+9 and gender != :gender)
+                    or ((:age < age or age >= :age+9) and gender = :gender)
+                    or (:age <= age < :age+9 and gender = :gender)
+                )
+    )
+   or (
+                    :age <= age < :age+9
+        and gender = :gender
+        and (
+                            (:tag1, :tag2) in ((tag1, tag2), (tag1, tag3),
+                                               (tag2, tag1), (tag2, tag3),
+                                               (tag3, tag1), (tag3, tag2))
+                        or
+                            (:tag1, :tag3) in ((tag1, tag2), (tag1, tag3),
+                                               (tag2, tag1), (tag2, tag3),
+                                               (tag3, tag1), (tag3, tag2))
+                        or
+                            (:tag2, :tag3) in ((tag1, tag2), (tag1, tag3),
+                                               (tag2, tag1), (tag2, tag3),
+                                               (tag3, tag1), (tag3, tag2))
+                    )
+        and (:tag1, :tag2, :tag3) not in (
+                                          (tag1, tag2, tag3),
+                                          (tag1, tag3, tag2),
+                                          (tag2, tag1, tag3),
+                                          (tag2, tag3, tag1),
+                                          (tag3, tag1, tag2),
+                                          (tag3, tag2, tag1)
+        )
+    )
+group by :targetId
+with rollup


### PR DESCRIPTION
## 🔖 관련 이슈
- #122 

## 📝 구현 사항
- 선택한 태그를 바디로 바다서 POST로 구현
- 태그 선택률이 80% 이상 비슷한 사용자의 각 옵션 선택률 (이하 선택률) 구현
- 원래 추천된 옵션의 아이디를 path variable로 받아서 선택한 부품의 선택률을 계산하는 것이었으나, 구현을 하다보니 전체 부품 판매량의 합계를 구해야 돼서 그냥 전체 다 계산할 수 있게 만듦..
- 그러다 보니 Collections.sort로 선택률이 높은 순으로 정렬할 수 있게 됨
- powertrain, bodytype, driving-system 은 model 테이블과 조인을 해야 돼서 속도가 느림 (최소 2초 이상)
- Sql 파일을 읽어서 value를 동적으로 매칭시키는 방식을 사용하고 싶었으나 select 문에서 오류가 계속 나서 (ex. select 문에서 powertrain_id를 계속 'powertrain_id' 자체로 인식하는 듯함) 깡 쿼리로 구현함.

## 📌 하고싶은 말
<img width="373" alt="image" src="https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/75351686/ec2c1e40-29ef-446c-b4ae-cc8d4ad3218b">

- powertrain, bodytype, driving-system 은 model 테이블과 조인을 해야 돼서 속도가 느림 (최소 2초 이상)
- Sql 파일을 읽어서 value를 동적으로 매칭시키는 방식을 사용하고 싶었으나 select 문에서 오류가 계속 나서 (ex. select 문에서 powertrain_id를 계속 'powertrain_id' 자체로 인식하는 듯함) 깡 쿼리로 구현함.