### PR TITLE
[BE] 가이드 모드 API 로직 수정 및 쿼리 최적화 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     runtimeOnly 'com.h2database:h2:1.4.197'
 

--- a/backend/src/main/java/com/example/backend/domain/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/example/backend/domain/global/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.example.backend.domain.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Bean
+    public CacheManager cacheManager() {
+        RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory());
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())) // Value Serializer 변경
+                .entryTtl(Duration.ofHours(12)); // 캐시 수명 12시간
+        builder.cacheDefaults(configuration);
+        return builder.build();
+    }
+
+}

--- a/backend/src/main/java/com/example/backend/domain/guide/service/CarRecommendationServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/CarRecommendationServiceImpl.java
@@ -32,6 +32,8 @@ public class CarRecommendationServiceImpl implements CarRecommendationService {
             return getRecommendWheelList(field, estimate);
         if (field.contains("color"))
             return optionRecommendationHandler.findTopSalesCountOfColor(field, estimate.getGender(), estimate.getAge());
+        if (field.contains("option"))
+            return optionRecommendationHandler.findAdditionalOptionByTag(field, estimate.getTagList());
         return getRecommendBaseOptionList(field, estimate);
     }
 
@@ -46,8 +48,8 @@ public class CarRecommendationServiceImpl implements CarRecommendationService {
 
 
     private List<Long> getRecommendBaseOptionList(String field, EstimateRequest estimate) {
-        List<Long> optionList = optionRecommendationHandler.findByTag(field, estimate.getTagList());
-        if (optionList.size() == 0 && !field.contains("option"))
+        List<Long> optionList = optionRecommendationHandler.findBaseOptionByTag(field, estimate.getTagList());
+        if (optionList.size() == 0)
             return optionRecommendationHandler.findTopSalesCount(field, estimate.getGender(), estimate.getAge());
         return optionList;
     }

--- a/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandler.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandler.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 public interface OptionRecommendationHandler {
     // 태그 3순위까지 순차적으로 조회한다.
-    List<Long> findByTag(String category, List<Long> tagId);
+    List<Long> findBaseOptionByTag(String category, List<Long> tagId);
+
+    List<Long> findAdditionalOptionByTag(String category, List<Long> tagIds);
 
     // 판매량이 가장 높은 옵션을 조회한다.
     List<Long> findTopSalesCount(String category, Gender gender, int age);

--- a/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandlerImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/guide/service/OptionRecommendationHandlerImpl.java
@@ -14,13 +14,22 @@ public class OptionRecommendationHandlerImpl implements OptionRecommendationHand
     private final TagOptionRepository tagOptionRepository;
 
     @Override
-    public List<Long> findByTag(String category, List<Long> tagIds) {
+    public List<Long> findBaseOptionByTag(String category, List<Long> tagIds) {
         for(Long tagId: tagIds) {
             List<Long> optionList = tagOptionRepository.findOptionIdByTagId(category, tagId);
             if(optionList.size() != 0)
                 return optionList;
         }
         return new ArrayList<>();
+    }
+
+    @Override
+    public List<Long> findAdditionalOptionByTag(String category, List<Long> tagIds) {
+        List<Long> result = new ArrayList<>();
+        for(Long tagId: tagIds) {
+            result.addAll(tagOptionRepository.findOptionIdByTagId(category, tagId));
+        }
+        return result;
     }
 
     @Override

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -9,6 +9,7 @@ import com.example.backend.domain.sale.service.SelectionRatioWithSimilarUsersSer
 import com.example.backend.domain.sale.service.SelfModeServiceFactory;
 import com.example.backend.domain.sale.service.TagSelectionRatioService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/controller/SaleRatioController.java
@@ -9,7 +9,6 @@ import com.example.backend.domain.sale.service.SelectionRatioWithSimilarUsersSer
 import com.example.backend.domain.sale.service.SelfModeServiceFactory;
 import com.example.backend.domain.sale.service.TagSelectionRatioService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/backend/src/main/java/com/example/backend/domain/sale/mapper/SummaryMapper.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/mapper/SummaryMapper.java
@@ -15,8 +15,8 @@ public class SummaryMapper {
 
     public List<RatioSummaryResponse> map(List<RatioSummary> dto) {
         int size = dto.size();
-        int totalCount = dto.get(size - 1).getSelectionCount();
-        return IntStream.range(0, size - 1)
+        int totalCount = dto.get(0).getSelectionCount();
+        return IntStream.range(1, size)
                 .mapToObj(dto::get)
                 .map(d -> calculateRatio(d, totalCount))
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/SalesOptionsRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/SalesOptionsRepository.java
@@ -12,14 +12,14 @@ import java.util.List;
 @Repository
 public interface SalesOptionsRepository extends CrudRepository<SalesOptions, Long> {
     @Query(
-            value = "SELECT * FROM (SELECT so.additional_option_id      AS id,\n" +
+            value = "SELECT ao.id, ao.select_count FROM (SELECT so.additional_option_id      AS id,\n" +
                     "       COUNT(*)                     AS select_count\n" +
                     "FROM SALES s\n" +
                     "INNER JOIN MODEL m ON s.model_id = m.id \n" +
-                    "INNER JOIN SALES_OPTIONS ON s.id = so.sales_id\n" +
+                    "INNER JOIN SALES_OPTIONS so ON s.id = so.sales_id\n" +
                     "WHERE m.trim_id = 1\n" +
                     "GROUP BY so.additional_option_id) ao, ADDITIONAL_OPTION\n" +
-                    "WHERE ao.id = ADDITIONAL_OPTION.id AND ADDITIONAL_OPTION.category = :category)\n",
+                    "WHERE ao.id = ADDITIONAL_OPTION.id AND ADDITIONAL_OPTION.category = :category\n",
             rowMapperClass = SelectionRatioRowMapper.class
     )
     List<RatioSummary> findSalesRatio(String category);

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/SalesOptionsRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/SalesOptionsRepository.java
@@ -14,12 +14,13 @@ public interface SalesOptionsRepository extends CrudRepository<SalesOptions, Lon
     @Query(
             value = "SELECT ao.id, ao.select_count FROM (SELECT so.additional_option_id      AS id,\n" +
                     "       COUNT(*)                     AS select_count\n" +
-                    "FROM SALES s\n" +
+                    "FROM SALES s \n" +
                     "INNER JOIN MODEL m ON s.model_id = m.id \n" +
                     "INNER JOIN SALES_OPTIONS so ON s.id = so.sales_id\n" +
                     "WHERE m.trim_id = 1\n" +
                     "GROUP BY so.additional_option_id) ao, ADDITIONAL_OPTION\n" +
-                    "WHERE ao.id = ADDITIONAL_OPTION.id AND ADDITIONAL_OPTION.category = :category\n",
+                    "WHERE ao.id = ADDITIONAL_OPTION.id AND ADDITIONAL_OPTION.category = :category\n" +
+                    "ORDER BY select_count DESC",
             rowMapperClass = SelectionRatioRowMapper.class
     )
     List<RatioSummary> findSalesRatio(String category);

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/SalesTemplateRepository.java
@@ -22,7 +22,7 @@ public class SalesTemplateRepository {
         String query = "SELECT m." + columnId + " AS id, COUNT(*) AS select_count FROM MODEL m \n" +
                 "INNER JOIN SALES s ON s.model_id = m.id \n" +
                 "WHERE m.trim_id = 1\n" +
-                "GROUP BY m." + columnId + " WITH ROLLUP ";
+                "GROUP BY m." + columnId + " WITH ROLLUP ORDER BY select_count DESC ";
 
         return jdbcTemplate.query(query, new SelectionRatioRowMapper());
     }
@@ -31,7 +31,7 @@ public class SalesTemplateRepository {
         String query = "SELECT s." + columnId + " AS id, COUNT(*) AS select_count FROM MODEL m \n" +
                 "INNER JOIN SALES s ON s.model_id = m.id \n" +
                 "WHERE m.trim_id = 1\n" +
-                "GROUP BY s." + columnId + " WITH ROLLUP ";
+                "GROUP BY s." + columnId + " WITH ROLLUP ORDER BY select_count DESC";
 
         return jdbcTemplate.query(query, new SelectionRatioRowMapper());
     }

--- a/backend/src/main/java/com/example/backend/domain/sale/repository/TagRatioTemplateRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/repository/TagRatioTemplateRepository.java
@@ -3,6 +3,7 @@ package com.example.backend.domain.sale.repository;
 import com.example.backend.domain.sale.entity.RatioSummary;
 import com.example.backend.domain.sale.mapper.SelectionRatioRowMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
@@ -27,6 +28,7 @@ public class TagRatioTemplateRepository {
         });
     }
 
+    @Cacheable(cacheNames = "TagSelectionCount")
     public List<RatioSummary> findBaseOptionCount(Long tagId, String category, Long optionId) {
         String category_id = category + "_id";
         String query = "SELECT * FROM (SELECT m." + category_id + " AS id, COUNT(*) AS select_count FROM MODEL m \n" +
@@ -48,6 +50,7 @@ public class TagRatioTemplateRepository {
         return jdbcTemplate.query(query, new SelectionRatioRowMapper());
     }
 
+    @Cacheable(cacheNames = "TagSelectionCount")
     public List<RatioSummary> findAdditionalOptionCount(Long tagId, String category, Long optionId) {
         String category_id = category + "_id";
         String query = "SELECT * FROM (SELECT so." + category_id + " AS id, COUNT(*) AS select_count FROM MODEL m \n" +

--- a/backend/src/main/java/com/example/backend/domain/sale/service/OptionSaleRatioServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/OptionSaleRatioServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.backend.domain.sale.entity.RatioSummary;
 import com.example.backend.domain.sale.repository.SalesOptionsRepository;
 import com.example.backend.domain.sale.repository.SalesRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,6 +16,7 @@ public class OptionSaleRatioServiceImpl implements RatioService {
     private final SalesRepository salesRepository;
 
     @Override
+    @Cacheable(cacheNames = "optionSelectionRatio", key="#category")
     public List<RatioSummary> findSaleRatio(String category) {
         List<RatioSummary> result = salesOptionsRepository.findSalesRatio(category.toUpperCase());
         Integer totalSales = salesRepository.getTotalSales();

--- a/backend/src/main/java/com/example/backend/domain/sale/service/OptionSaleRatioServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/OptionSaleRatioServiceImpl.java
@@ -18,7 +18,7 @@ public class OptionSaleRatioServiceImpl implements RatioService {
     public List<RatioSummary> findSaleRatio(String category) {
         List<RatioSummary> result = salesOptionsRepository.findSalesRatio(category.toUpperCase());
         Integer totalSales = salesRepository.getTotalSales();
-        result.add(new RatioSummary(Long.MAX_VALUE, totalSales));
+        result.add(0, new RatioSummary(Long.MAX_VALUE, totalSales));
         return result;
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/domain/sale/service/SelectionRatioWithSimilarUsersServiceImpl.java
@@ -37,7 +37,7 @@ public class SelectionRatioWithSimilarUsersServiceImpl implements SelectionRatio
 
     private List<RatioSummaryResponse> getSortedRatioSummaryResponses(List<RatioSummary> summaries) {
         List<RatioSummaryResponse> result = summaryMapper.map(summaries);
-        Collections.sort(result, (o1, o2) -> o2.getSelectionRatio() - o1.getSelectionRatio());
+//        Collections.sort(result, (o1, o2) -> o2.getSelectionRatio() - o1.getSelectionRatio());
         return result;
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -16,3 +16,8 @@ spring:
       mode: always
       schema-locations: classpath:sql/scheme.sql
       data-locations: classpath:sql/data.sql
+  cache:
+    type: redis
+  redis:
+    host: 127.0.0.1
+    port: 63


### PR DESCRIPTION
## 🔖 관련 이슈
- #122, #123 

## 📝 구현 사항
- 쿼리 최적화 (인덱싱)
  - 추가한 인덱스
    - model_age
    - gender_model_exterior_age
    - gender_model_interior_age
    - model_exterior_age
    - model_interior_age
    - gender_model_wheel_age
    - model_wheel_age
    - model_wheel
    - model_interior
    - model_exterior
    - sales_option
    - category
    - model_tags
    - gender_model_age_tag
    - gender_model_wheel_age_tag
- 로직 수정
  - 판매율 계산시에도 정렬하도록 수정
  - 유사 사용자 계산 로직에서 80% -> 연령 + 나이 + 태그 고려하도록 수정(기획서 참고)
  - 최적화에 따른 쿼리 수정

## 📌 하고싶은 말
- 그래도 느린 것들은 캐시 걸어볼게요... :(
