### PR TITLE
[iOS] 선택완료 연속 클릭 이슈 수정, 옵션 선택 단계에서는 피드백 모션 실행 X

### DIFF
--- a/iOS_H3/DTO/CarInfo/SelfModeUsecase.swift
+++ b/iOS_H3/DTO/CarInfo/SelfModeUsecase.swift
@@ -117,7 +117,10 @@ class SelfModeUsecase: SelfModeUsecaseProtocol {
         return Just(updatedSummary).eraseToAnyPublisher()
     }
 
-    func fetchFeedbackComment(step: CarMakingStep) -> AnyPublisher<FeedbackComment, Error> {
+    func fetchFeedbackComment(step: CarMakingStep) -> AnyPublisher<FeedbackComment?, Error> {
+        if step == .optionSelection || step == .makingEstimate {
+            return Just(nil).setFailureType(to: Error.self).eraseToAnyPublisher()
+        }
         guard let selectedOption = carMakingTotalInfo[step]?.optionCardInfoArray.first(where: { $0.isSelected }) else {
             return Fail(error: SelfModeUsecaseError.notExistSelectedOption).eraseToAnyPublisher()
         }

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -140,6 +140,11 @@ extension CarMakingViewController {
         output.feedbackComment
             .receive(on: DispatchQueue.main)
             .sink { [weak self] feedbackComment in
+                guard let feedbackComment else {
+                    self?.carMakingContentView.moveNextStep()
+                    self?.isBlockedNextButton = false
+                    return
+                }
                 self?.carMakingContentView.playFeedbackAnimation(with: feedbackComment) { [weak self] in
                     self?.carMakingContentView.moveNextStep()
                     self?.isBlockedNextButton = false

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -138,7 +138,9 @@ extension CarMakingViewController {
         output.feedbackComment
             .receive(on: DispatchQueue.main)
             .sink { [weak self] feedbackComment in
-                self?.carMakingContentView.moveNextStep(with: feedbackComment)
+                self?.carMakingContentView.playFeedbackAnimation(with: feedbackComment) { [weak self] in
+                    self?.carMakingContentView.moveNextStep()
+                }
             }
             .store(in: &cancellables)
 

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -43,6 +43,8 @@ final class CarMakingViewController: UIViewController {
 
     private let nextButtonDidTapped = PassthroughSubject<Void, Never>()
 
+    private var isBlockedNextButton = false
+
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Lifecycles
@@ -140,6 +142,7 @@ extension CarMakingViewController {
             .sink { [weak self] feedbackComment in
                 self?.carMakingContentView.playFeedbackAnimation(with: feedbackComment) { [weak self] in
                     self?.carMakingContentView.moveNextStep()
+                    self?.isBlockedNextButton = false
                 }
             }
             .store(in: &cancellables)
@@ -227,7 +230,10 @@ extension CarMakingViewController: BottomModalViewDelegate {
     }
 
     func bottomModalViewCompletionButtonDidTapped(_ bottomModalView: BottomModalView) {
-        nextButtonDidTapped.send(())
+        if !isBlockedNextButton {
+            nextButtonDidTapped.send(())
+            isBlockedNextButton = true
+        }
     }
 }
 

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
@@ -29,7 +29,7 @@ final class CarMakingViewModel {
         var optionInfoDidUpdated = PassthroughSubject<[OptionCardInfo], Never>()
         var optionInfoForCategory = PassthroughSubject<[OptionCardInfo], Never>()
         var numberOfSelectedAdditionalOption = PassthroughSubject<Int, Never>()
-        var feedbackComment = PassthroughSubject<FeedbackComment, Never>()
+        var feedbackComment = PassthroughSubject<FeedbackComment?, Never>()
         var showIndicator = PassthroughSubject<Bool, Never>()
         var isDictionaryFeatureEnabled = CurrentValueSubject<Bool, Never>(false)
     }
@@ -178,7 +178,7 @@ final class CarMakingViewModel {
 
     private func fetchFeedbackComment(
         for step: CarMakingStep,
-        to feedbackCommentSubject: PassthroughSubject<FeedbackComment, Never>
+        to feedbackCommentSubject: PassthroughSubject<FeedbackComment?, Never>
     ) {
         selfModeUsecase.fetchFeedbackComment(step: step)
             .catch { _ in Just(FeedbackComment(title: "", subTitle: "")).eraseToAnyPublisher() }

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
@@ -89,13 +89,11 @@ class CarMakingContentView<Section: CarMakingSectionType>: UIView, UICollectionV
 
     // MARK: - Helpers
 
-    func moveNextStep(with feedbackCommment: FeedbackComment) {
+    func playFeedbackAnimation(with feedbackComment: FeedbackComment, completion: (() -> Void)? = nil) {
         guard currentStep < CarMakingStep.allCases.count - 1 else { return }
         let indexPath = Section.indexPath(for: currentStep)
         if let cell = collectionView.cellForItem(at: indexPath) as? CarMakingCollectionViewCell {
-            cell.playFeedbackAnimation(with: feedbackCommment, completion: {[weak self] in
-                self?.currentStep += 1
-            })
+            cell.playFeedbackAnimation(with: feedbackComment, completion: completion)
         }
     }
 

--- a/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingContentView/CarMakingContentView.swift
@@ -97,6 +97,11 @@ class CarMakingContentView<Section: CarMakingSectionType>: UIView, UICollectionV
         }
     }
 
+    func moveNextStep() {
+        guard currentStep < CarMakingStep.allCases.count - 1 else { return }
+        currentStep += 1
+    }
+
     func movePrevStep() {
         guard currentStep > 0 else { return }
         currentStep -= 1

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -61,7 +61,6 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
     func configure(with cardInfos: [OptionCardInfo], step: CarMakingStep) {
         optionCardButtons.enumerated().forEach { (index, _) in
             if cardInfos.count <= index { return }
-            print("확인", cardInfos[index])
             configureOptionCard(at: index, with: cardInfos[index], step: step)
         }
     }

--- a/iOS_H3/iOS_H3_UI/OptionListView/SelfModeUsecaseProtocol.swift
+++ b/iOS_H3/iOS_H3_UI/OptionListView/SelfModeUsecaseProtocol.swift
@@ -55,5 +55,5 @@ protocol SelfModeUsecaseProtocol {
         selectedOption: OptionCardInfo
     ) -> AnyPublisher<EstimateSummary, Never>
 
-	func fetchFeedbackComment(step: CarMakingStep) -> AnyPublisher<FeedbackComment, Error>
+	func fetchFeedbackComment(step: CarMakingStep) -> AnyPublisher<FeedbackComment?, Error>
 }


### PR DESCRIPTION
## 🔖 관련 이슈
- #253 

## 📝 구현 사항

- 선택 완료 연속 클릭 시 피드백 모션이 계속해서 실행되는 이슈를 수정했습니다.
- 옵션 선택 단계와 견적내기 단계에서는 선택 완료 클릭 시에도 피드백 모션이 실행되지 않고 다음 단계로 전환되도록 했습니다

선택완료 연속 클릭 이슈 수정 | 옵션 선택 단계는 피드백 모션 실행 X
---|---
![화면 기록 2023-08-28 오전 3 37 19](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/f4ebe76b-d41c-4296-af80-a6d5d96a977a) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-28 at 03 41 06](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/8f5c078a-730f-4f8c-8d5a-63e864ecb486)
