### PR TITLE
[iOS] 백카사전 관련 여러 이슈 수정

### DIFF
--- a/iOS_H3/iOS_H3/Source/Data/Repository/CarInfoMockRepository.swift
+++ b/iOS_H3/iOS_H3/Source/Data/Repository/CarInfoMockRepository.swift
@@ -91,13 +91,13 @@ struct CarMakingMockRepositoryData {
     static var mockOption = [
         [OptionCardInfoEntity.init(
             id: 0,
-            title: "디젤 2.2",
+            title: "<cardb>디젤</cardb> 2.2",
             subTitle: "구매자의 63%가 선택한",
             priceString: "+ 3,456,789원",
             bannerImageURL: mockURL[0]),
          OptionCardInfoEntity.init(
             id: 1,
-            title: "가솔린 3.8",
+            title: "<cardb>가솔린</cardb> 3.8",
             subTitle: "구매자의 37%가 선택한",
             priceString: "+ 3,456,789원",
             bannerImageURL: mockURL[1])],
@@ -127,14 +127,14 @@ struct CarMakingMockRepositoryData {
             bannerImageURL: mockURL[3])],
         [OptionCardInfoEntity.init(
             id: 6,
-            title: "크리미 화이트 펄",
+            title: "<cardb>크리미</cardb> 화이트 펄",
             subTitle: "구매자의 88%가 선택한",
             priceString: "+ 3,456,789원",
             bannerImageURL: mockURL[4],
             color: URColor(red: 0, green: 0, blue: 0)),
          OptionCardInfoEntity.init(
             id: 7,
-            title: "LK-99 3.8",
+            title: "<cardb>LK-99</cardb> 3.8",
             subTitle: "구매자의 12%가 선택한",
             priceString: "+ 3,456,789원",
             bannerImageURL: mockURL[0])],
@@ -166,13 +166,13 @@ struct CarMakingMockRepositoryData {
             bannerImageURL: mockURL[4])],
         [OptionCardInfoEntity.init(
             id: 12,
-            title: "가솔린 3.8",
+            title: "<cardb>가솔린</cardb> 3.8",
             subTitle: "구매자의 63%가 선택한",
             priceString: "+ 3,456,789원",
             bannerImageURL: mockURL[3]),
          OptionCardInfoEntity.init(
             id: 13,
-            title: "가솔린 3.8",
+            title: "<cardb>가솔린</cardb> 3.8",
             subTitle: "구매자의 63%가 선택한",
             priceString: "+ 3,456,789원",
             bannerImageURL: mockURL[0])],

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -108,10 +108,7 @@ extension CarMakingViewController {
             .sink { [weak self] optionInfo in
                 self?.carMakingContentView.updateOptionCard(with: optionInfo)
                 if let view = self?.view {
-                    if output.isDictionaryFeatureEnabled.value {
-                        TextEffectManager.shared.applyEffect(false, on: view)
-                        TextEffectManager.shared.applyEffect(true, on: view)
-                    }
+                    TextEffectManager.shared.applyEffect(TextEffectManager.shared.isDictionaryFunctionActive, on: view)
                 }
             }
             .store(in: &cancellables)

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -29,8 +29,6 @@ final class CarMakingViewController: UIViewController {
 
     private let viewModel: CarMakingViewModel
 
-    private let textEffectManager = TextEffectManager.shared
-
     private let viewDidLoadSubject = PassthroughSubject<Void, Never>()
 
     private let stepDidChanged = CurrentValueSubject<CarMakingStep, Never>(.powertrain)
@@ -111,8 +109,8 @@ extension CarMakingViewController {
                 self?.carMakingContentView.updateOptionCard(with: optionInfo)
                 if let view = self?.view {
                     if output.isDictionaryFeatureEnabled.value {
-                        self?.textEffectManager.applyEffect(false, on: view)
-                        self?.textEffectManager.applyEffect(true, on: view)
+                        TextEffectManager.shared.applyEffect(false, on: view)
+                        TextEffectManager.shared.applyEffect(true, on: view)
                     }
                 }
             }
@@ -151,7 +149,7 @@ extension CarMakingViewController {
         output.isDictionaryFeatureEnabled
             .sink { [weak self] isEnabled in
                 if let view = self?.view {
-                    self?.textEffectManager.applyEffect(isEnabled, on: view)
+                    TextEffectManager.shared.applyEffect(isEnabled, on: view)
                 }
             }
             .store(in: &cancellables)

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -226,6 +226,7 @@ extension CarMakingViewController {
     private func setupTitleBar() {
         let titleBarType: OhMyCarSetTitleBar.NavigationBarType = (mode == .selfMode) ? .selfMode : .guideMode
         titleBar = OhMyCarSetTitleBar(type: titleBarType)
+        titleBar.isDictionaryButtonOn = TextEffectManager.shared.isDictionaryFunctionActive
         titleBar.delegate = self
         titleBar.translatesAutoresizingMaskIntoConstraints = false
     }

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -106,9 +106,6 @@ extension CarMakingViewController {
         output.optionInfoDidUpdated
             .sink { [weak self] optionInfo in
                 self?.carMakingContentView.updateOptionCard(with: optionInfo)
-                if let view = self?.view {
-                    TextEffectManager.shared.applyEffect(TextEffectManager.shared.isDictionaryFunctionActive, on: view)
-                }
             }
             .store(in: &cancellables)
 

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -171,7 +171,7 @@ extension CarMakingViewController: OhMyCarSetTitleBarDelegate {
 
     func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         let isOn = TextEffectManager.shared.isDictionaryFunctionActive
-        TextEffectManager.shared.applyEffect(!isOn, on: self.view)
+        TextEffectManager.shared.applyEffectSubviews(!isOn, on: self.view)
     }
 
     func titleBarChangeModelButtonPressed(_ titleBar: OhMyCarSetTitleBar) {

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewController/CarMakingViewController.swift
@@ -99,7 +99,6 @@ extension CarMakingViewController {
         output.currentStepInfo
             .receive(on: DispatchQueue.main)
             .sink { [weak self] info in
-                self?.titleBar.resetDictionary()
                 self?.updateCurrentStepInfo(with: info)
             }
             .store(in: &cancellables)
@@ -142,14 +141,6 @@ extension CarMakingViewController {
                 self?.showIndicator(showIndicator)
             }
             .store(in: &cancellables)
-
-        output.isDictionaryFeatureEnabled
-            .sink { [weak self] isEnabled in
-                if let view = self?.view {
-                    TextEffectManager.shared.applyEffect(isEnabled, on: view)
-                }
-            }
-            .store(in: &cancellables)
     }
 
     private func updateBottomModalView(with estimateData: EstimateSummary) {
@@ -182,7 +173,8 @@ extension CarMakingViewController: OhMyCarSetTitleBarDelegate {
     }
 
     func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
-        dictionaryButtonPressed.send(())
+        let isOn = TextEffectManager.shared.isDictionaryFunctionActive
+        TextEffectManager.shared.applyEffect(!isOn, on: self.view)
     }
 
     func titleBarChangeModelButtonPressed(_ titleBar: OhMyCarSetTitleBar) {

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
@@ -31,7 +31,6 @@ final class CarMakingViewModel {
         var numberOfSelectedAdditionalOption = PassthroughSubject<Int, Never>()
         var feedbackComment = PassthroughSubject<FeedbackComment, Never>()
         var showIndicator = PassthroughSubject<Bool, Never>()
-        var isDictionaryFeatureEnabled = CurrentValueSubject<Bool, Never>(false)
     }
 
     // MARK: - Properties
@@ -64,7 +63,6 @@ final class CarMakingViewModel {
                     category: input.optionCategoryDidChanged.value,
                     output: output.currentStepInfo
                 )
-                output.isDictionaryFeatureEnabled.send(false)
             }
             .store(in: &cancellables)
 
@@ -87,13 +85,6 @@ final class CarMakingViewModel {
         input.optionCategoryDidChanged
             .sink { [weak self] newCategory in
                 self?.fetchOptionSelectionStepInfo(for: newCategory, to: output.optionInfoForCategory)
-            }
-            .store(in: &cancellables)
-
-        input.dictionaryButtonPressed
-            .sink { _ in
-                let currentValue = output.isDictionaryFeatureEnabled.value
-                output.isDictionaryFeatureEnabled.send(!currentValue)
             }
             .store(in: &cancellables)
 

--- a/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/CarMaking/ViewModel/CarMakingViewModel.swift
@@ -40,9 +40,6 @@ final class CarMakingViewModel {
 
     private let selfModeUsecase: SelfModeUsecaseProtocol
 
-    var feedbackTitle: String = ""
-    var feedbackDescription: String = ""
-
     // MARK: - Lifecycles
 
     init(selfModeUsecase: SelfModeUsecaseProtocol) {

--- a/iOS_H3/iOS_H3/Source/Presentation/MainViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/MainViewController.swift
@@ -70,7 +70,7 @@ final class MainViewController: UIViewController {
         let isOn = TextEffectManager.shared.isDictionaryFunctionActive
         if titleBar.isDictionaryButtonOn != isOn {
             titleBar.isDictionaryButtonOn = isOn
-            TextEffectManager.shared.applyEffect(isOn, on: view)
+            TextEffectManager.shared.applyEffectSubviews(isOn, on: view)
         }
     }
 }
@@ -84,7 +84,7 @@ extension MainViewController: OhMyCarSetTitleBarDelegate {
 
     func titleBarDictionaryButtonPressed(_ titleBar: OhMyCarSetTitleBar) {
         let isDictionaryOn = TextEffectManager.shared.isDictionaryFunctionActive
-        TextEffectManager.shared.applyEffect(!isDictionaryOn, on: view)
+        TextEffectManager.shared.applyEffectSubviews(!isDictionaryOn, on: view)
     }
 }
 

--- a/iOS_H3/iOS_H3/Source/Presentation/MainViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/MainViewController.swift
@@ -59,7 +59,20 @@ final class MainViewController: UIViewController {
         setupViews()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        applyTextEffectIfNeeded()
+    }
+
     // MARK: - Helpers
+
+    private func applyTextEffectIfNeeded() {
+        let isOn = TextEffectManager.shared.isDictionaryFunctionActive
+        if titleBar.isDictionaryButtonOn != isOn {
+            titleBar.isDictionaryButtonOn = isOn
+            TextEffectManager.shared.applyEffect(isOn, on: view)
+        }
+    }
 }
 
 // MARK: - OhMyCarSetTitleBar Delegate

--- a/iOS_H3/iOS_H3/Source/Presentation/OptionDetail/ViewController/ImageDetailPopupViewController.swift
+++ b/iOS_H3/iOS_H3/Source/Presentation/OptionDetail/ViewController/ImageDetailPopupViewController.swift
@@ -169,7 +169,7 @@ class ImageDetailPopupViewController: UIViewController {
 
     private func applyDictionaryEffectIfNeeded(view: UIView) {
         guard textEffectManager.isDictionaryFunctionActive else { return }
-        textEffectManager.applyEffect(true, on: view)
+        textEffectManager.applyEffectSubviews(true, on: view)
     }
 }
 

--- a/iOS_H3/iOS_H3/Source/TextEffectManager.swift
+++ b/iOS_H3/iOS_H3/Source/TextEffectManager.swift
@@ -20,6 +20,13 @@ class TextEffectManager {
 
     func applyEffect(_ isOn: Bool, on view: UIView) {
         isDictionaryFunctionActive = isOn
+
+        if let label = view as? URLabel, let dictionaryStr = label.urString {
+            observeLabel(label)
+            label.setURString(dictionaryStr, isOn: isOn)
+        }
+    }
+
     func applyEffectSubviews(_ isOn: Bool, on view: UIView) {
         isDictionaryFunctionActive = isOn
 

--- a/iOS_H3/iOS_H3/Source/TextEffectManager.swift
+++ b/iOS_H3/iOS_H3/Source/TextEffectManager.swift
@@ -20,12 +20,15 @@ class TextEffectManager {
 
     func applyEffect(_ isOn: Bool, on view: UIView) {
         isDictionaryFunctionActive = isOn
+    func applyEffectSubviews(_ isOn: Bool, on view: UIView) {
+        isDictionaryFunctionActive = isOn
+
         for subview in view.subviews {
             if let label = subview as? URLabel, let dictionaryStr = label.urString {
                 observeLabel(label)
                 label.setURString(dictionaryStr, isOn: isOn)
             } else {
-                applyEffect(isOn, on: subview)
+                applyEffectSubviews(isOn, on: subview)
             }
         }
     }

--- a/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
+++ b/iOS_H3/iOS_H3_UI/CarMakingCollectionViewCell/CarMakingCollectionViewCell.swift
@@ -93,6 +93,11 @@ class CarMakingCollectionViewCell: UICollectionViewCell {
 
     func configure(urString: URString?) {
         self.descriptionLabel.urString = urString
+
+        let isOn = TextEffectManager.shared.isDictionaryFunctionActive
+        if isOn {
+            TextEffectManager.shared.applyEffect(isOn, on: descriptionLabel)
+        }
     }
 
     func configure(bannerImageURL: URL?) {

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
@@ -65,7 +65,7 @@ final class OptionCardCell: UICollectionViewCell {
 
     func configure(carMakingMode: CarMakingMode, info: OptionCardInfo, step: CarMakingStep) {
         optionCardButton.update(carMakingMode: carMakingMode, cardInfo: info, step: step)
-        TextEffectManager.shared.applyEffect(TextEffectManager.shared.isDictionaryFunctionActive, on: optionCardButton)
+        TextEffectManager.shared.applyEffectSubviews(TextEffectManager.shared.isDictionaryFunctionActive, on: optionCardButton)
     }
 
     func playFeedbackAnimation(with feedbackComment: FeedbackComment, completion: (() -> Void)? = nil) {

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
@@ -65,6 +65,7 @@ final class OptionCardCell: UICollectionViewCell {
 
     func configure(carMakingMode: CarMakingMode, info: OptionCardInfo, step: CarMakingStep) {
         optionCardButton.update(carMakingMode: carMakingMode, cardInfo: info, step: step)
+        TextEffectManager.shared.applyEffect(TextEffectManager.shared.isDictionaryFunctionActive, on: optionCardButton)
     }
 
     func playFeedbackAnimation(with feedbackComment: FeedbackComment, completion: (() -> Void)? = nil) {

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/OptionCardCell.swift
@@ -65,7 +65,10 @@ final class OptionCardCell: UICollectionViewCell {
 
     func configure(carMakingMode: CarMakingMode, info: OptionCardInfo, step: CarMakingStep) {
         optionCardButton.update(carMakingMode: carMakingMode, cardInfo: info, step: step)
-        TextEffectManager.shared.applyEffectSubviews(TextEffectManager.shared.isDictionaryFunctionActive, on: optionCardButton)
+        let isOn = TextEffectManager.shared.isDictionaryFunctionActive
+        if isOn {
+            TextEffectManager.shared.applyEffectSubviews(isOn, on: optionCardButton)
+        }
     }
 
     func playFeedbackAnimation(with feedbackComment: FeedbackComment, completion: (() -> Void)? = nil) {

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -61,7 +61,6 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
     func configure(with cardInfos: [OptionCardInfo], step: CarMakingStep) {
         optionCardButtons.enumerated().forEach { (index, _) in
             if cardInfos.count <= index { return }
-            print("확인", cardInfos[index])
             configureOptionCard(at: index, with: cardInfos[index], step: step)
         }
     }

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -68,12 +68,18 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     func reloadOptionCards(with cardInfos: [OptionCardInfo], step: CarMakingStep) {
         configure(with: cardInfos, step: step)
+        applyTextEffectIfNeeded()
     }
 
     func playFeedbackAnimation(with feedbackComment: FeedbackComment, completion: (() -> Void)? = nil) {
         for button in optionCardButtons where button.isSelected {
             button.animateButton(with: feedbackComment, completion: completion)
         }
+    }
+
+    private func applyTextEffectIfNeeded() {
+        let isOn = TextEffectManager.shared.isDictionaryFunctionActive
+        TextEffectManager.shared.applyEffect(isOn, on: self)
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -78,7 +78,7 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     private func applyTextEffectIfNeeded() {
         let isOn = TextEffectManager.shared.isDictionaryFunctionActive
-        TextEffectManager.shared.applyEffect(isOn, on: self)
+        TextEffectManager.shared.applyEffectSubviews(isOn, on: self)
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -78,7 +78,9 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
 
     private func applyTextEffectIfNeeded() {
         let isOn = TextEffectManager.shared.isDictionaryFunctionActive
-        TextEffectManager.shared.applyEffectSubviews(isOn, on: self)
+        if isOn {
+            TextEffectManager.shared.applyEffectSubviews(isOn, on: self)
+        }
     }
 }
 

--- a/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButonListView/TwoOptionCardButtonView/TwoOptionCardButtonView.swift
@@ -63,11 +63,11 @@ final class TwoOptionCardButtonView: UIView, OptionCardButtonListViewable {
             if cardInfos.count <= index { return }
             configureOptionCard(at: index, with: cardInfos[index], step: step)
         }
+        applyTextEffectIfNeeded()
     }
 
     func reloadOptionCards(with cardInfos: [OptionCardInfo], step: CarMakingStep) {
         configure(with: cardInfos, step: step)
-        applyTextEffectIfNeeded()
     }
 
     func playFeedbackAnimation(with feedbackComment: FeedbackComment, completion: (() -> Void)? = nil) {

--- a/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
+++ b/iOS_H3/iOS_H3_UI/OptionCardButton/OptionCardButton.swift
@@ -178,6 +178,7 @@ class OptionCardButton: UIButton {
         }
         self.step = step
         if let cardInfo = cardInfo {
+            optionTitleLabel.urString = cardInfo.title
             self.optionTitleLabel.text = cardInfo.title.fullText
             self.optionSubTitleLabel.text = cardInfo.subTitle.fullText
             self.priceLabel.text = cardInfo.priceString

--- a/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBar.swift
+++ b/iOS_H3/iOS_H3_UI/TitleBar/OhMyCarSetTitleBar.swift
@@ -145,10 +145,6 @@ class OhMyCarSetTitleBar: UIView {
         }
     }
 
-    func resetDictionary() {
-        isDictionaryButtonOn = false
-    }
-
     private func createBackButton() -> UIButton {
         let button = UIButton()
         button.setImage(UIImage(named: "arrow_left_img"), for: .normal)
@@ -195,8 +191,6 @@ class OhMyCarSetTitleBar: UIView {
 
     @objc private func dictionaryButtonTapped(_ sender: UIButton) {
         isDictionaryButtonOn.toggle()
-//        let buttonImage = isDictionaryButtonOn ? "dictionary_on_img" : "dictionary_off_img"
-//        sender.setImage(UIImage(named: buttonImage), for: .normal)
         delegate?.titleBarDictionaryButtonPressed?(self)
     }
 


### PR DESCRIPTION
## 🔖 관련 이슈
- #255 

## 📝 구현 사항

- 메인 화면 <-> 내차만들기 화면 전환 시에도 백카사전 On/Off 상태에 맞추어 화면 표시
- 내차만들기에서 다음 단계로 넘어갔을 때에도 백카사전 켜진 상태 유지
- 옵션 선택 시 백카사전 껐다 키던 로직 수정. `configure` 시점에 백카사전 On/Off 여부에 따라 하이라이팅 효과 적용

  ```
  옵션 카드를 업데이트 하는 흐름 크게 2가지
  1. TwoOptionCardButtonView
  2. Multi 와 ListModeView
  
  1의 경우, view configure 시점에 백카사전 on/off 여부 확인 후 해당 view에 텍스트 이펙트 적용
  2의 경우, 옵션 카드를 나타낼 때 OptionCardCell을 이용하므로 Cell의 configure 시점에 백카사전 on/off 여부 확인 후 해당 view에 텍스트 이펙트 적용
  ```

화면 전환 시 백카사전 킨 상태 유지 | 화면 전환 시 백카사전 끈 상태 유지 | 다음 단계 전환 시 백카사전 유지
---|---|---
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-28 at 11 33 07](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/4ce1ae53-993e-475d-8209-62d73c26eff8) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-28 at 11 33 47](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/4588c271-e2e9-4f9c-8065-0a78a65a3a8e) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-28 at 11 34 07](https://github.com/softeerbootcamp-2nd/H3-UmochaRacer/assets/68235938/8c654642-190b-40ea-9f46-c740ddc83891)


## 📌 하고싶은 말

드디어 끝 ~~ 고생많으셨습니다 (끝이겠죠 ..)